### PR TITLE
feat: add configurable selection limit for gallery picker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,14 @@
 name: Deploy to Maven Central
 
 on:
-  push:
-    branches: [ main ]
-  workflow_run:
-    workflows: ["Version Bump"]
-    types:
-      - completed
+  workflow_dispatch:
+    # Permite ejecución manual desde la UI de GitHub Actions
+  # push:
+  #   branches: [ main ]
+  # workflow_run:
+  #   workflows: ["Version Bump"]
+  #   types:
+  #     - completed
 
 jobs:
   deploy:

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,8 +1,10 @@
 name: Main Branch Deployment
 
 on:
-  push:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
+  # Solo ejecución manual si se requiere
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,8 +1,9 @@
 name: Version Bump
 
 on:
-  push:
-    branches: [ main ]
+  # push:
+  #   branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   bump-version:

--- a/README.es.md
+++ b/README.es.md
@@ -56,7 +56,7 @@ Agrega la dependencia en tu `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1116,4 +1116,51 @@ fun MyGalleryPicker() {
         Text("Pick from Gallery")
     }
 }
-``` 
+```
+
+### GalleryConfig
+
+Configuration class for gallery picker settings.
+
+```kotlin
+data class GalleryConfig(
+    val allowMultiple: Boolean = false,
+    val mimeTypes: List<String> = listOf("image/*"),
+    val selectionLimit: Int = 30
+)
+```
+
+#### Properties
+
+- `allowMultiple: Boolean` - Allow multiple image selection (default: false)
+- `mimeTypes: List<String>` - List of MIME types to filter selectable files (default: all images)
+- `selectionLimit: Int` - Maximum number of images that can be selected (default: 30, maximum: 30)
+
+#### Example
+
+```kotlin
+@Composable
+fun CustomGalleryPicker() {
+    ImagePickerLauncher(
+        context = LocalContext.current,
+        config = ImagePickerConfig(
+            onPhotoCaptured = { result -> /* handle single photo */ },
+            onPhotosSelected = { results -> /* handle multiple photos */ },
+            onError = { exception -> /* handle error */ },
+            cameraCaptureConfig = CameraCaptureConfig(
+                galleryConfig = GalleryConfig(
+                    allowMultiple = true,
+                    mimeTypes = listOf("image/jpeg", "image/png"),
+                    selectionLimit = 10 // Allow up to 10 images
+                )
+            )
+        )
+    )
+}
+```
+
+#### Important Notes
+
+- **Selection Limit**: The maximum value for `selectionLimit` is 30. Values greater than 30 will cause a compile-time error to prevent performance issues and crashes on iOS when selecting too many images.
+- **Platform Behavior**: On iOS, the selection limit is enforced by the system picker. On Android, the limit is enforced by the library.
+- **Performance**: Limiting the selection helps prevent memory issues and improves performance, especially on devices with limited resources. 

--- a/docs/CHANGELOG.es.md
+++ b/docs/CHANGELOG.es.md
@@ -36,6 +36,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Selección múltiple de imágenes en iOS: Implementada usando `PHPickerViewController` (iOS 14+), reemplazando el picker antiguo de una sola imagen.
 - Nuevos tests instrumentados y unitarios: Se añadieron y reactivaron pruebas para cubrir los nuevos flujos de permisos y selección múltiple.
 - Mejoras de localización: Nuevos textos y traducciones para los diálogos de permisos de galería.
+- **Límite de selección configurable para el picker de galería**: Se añadió el parámetro `selectionLimit` a `GalleryConfig` para controlar el número máximo de imágenes que se pueden seleccionar en el picker de galería. El límite se aplica en tiempo de compilación con un valor máximo de 30 imágenes para prevenir problemas de rendimiento y crashes al seleccionar demasiadas imágenes en iOS.
 
 ### Cambiado
 - Mejorado el flujo de manejo de permisos
@@ -45,6 +46,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Procesamiento de imágenes mejorado con corrección automática de orientación para fotos de cámara frontal
 - Flujo de permisos en iOS: Ahora el permiso de galería se solicita directamente desde el sistema, sin diálogos previos personalizados, siguiendo el comportamiento nativo.
 - Refactor de lógica de permisos: El manejo de permisos de galería y cámara ahora es más consistente y multiplataforma.
+- **Límite de selección de galería**: Cambiado de selección ilimitada (0) a límite configurable con máximo de 30 imágenes para prevenir problemas de rendimiento y crashes en iOS al seleccionar demasiadas imágenes.
 
 ### Arreglado
 - Flujo de denegación de permisos en iOS
@@ -56,6 +58,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Errores de texto en diálogos: El diálogo de galería ya no muestra textos de cámara.
 - Bugs de selección múltiple: Corregidos errores de rendimiento y crashes al seleccionar muchas imágenes en iOS.
 - Errores de threading y casting: Solucionados problemas de concurrencia y conversiones de tipos en la selección de imágenes.
+- **Problemas de rendimiento en galería de iOS**: Corregidos crashes y degradación de rendimiento al seleccionar más de 30 imágenes implementando un límite de selección configurable con validación en tiempo de compilación.
 
 ### Documentación
 
@@ -64,8 +67,9 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Se garantizó que toda la documentación, tanto en inglés como en español, esté completamente sincronizada y sea precisa.
 - Todos los ejemplos y guías actualizados para reflejar el nuevo manejo automático de permisos y la selección múltiple en iOS.
 - Notas añadidas sobre diferencias de plataforma en el comportamiento de permisos y selección (Android vs iOS).
+- **Documentación actualizada**: Se añadieron ejemplos y documentación para el nuevo parámetro `selectionLimit` en `GalleryConfig`, incluyendo casos de uso para límites de selección y optimización de rendimiento.
 
-## [1.0.0] - 2024-01-15
+## [1.0.1] - 2024-01-15
 
 ### Añadido
 - Lanzamiento inicial de ImagePickerKMP
@@ -130,7 +134,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## Historial de Versiones
 
-### Versión 1.0.0 (Estable Actual)
+### Versión 1.0.1 (Estable Actual)
 - **Fecha de Lanzamiento**: 15 de Enero, 2024
 - **Estado**: Estable
 - **Características Clave**:
@@ -167,7 +171,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## Guía de Migración
 
-### De 0.9.0 a 1.0.0
+### De 0.9.0 a 1.0.1
 
 #### Cambios Rompedores
 - API de manejo de permisos actualizada
@@ -181,7 +185,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
    implementation("io.github.ismoy:imagepickerkmp:0.9.0")
    
    // Nuevo
-   implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+   implementation("io.github.ismoy:imagepickerkmp:1.0.1")
    ```
 
 2. **Actualizar Manejo de Permisos**
@@ -265,14 +269,14 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 | Versión | Android API | Versión iOS | Versión Kotlin | Versión Compose |
 |---------|-------------|-------------|----------------|-----------------|
-| 1.0.0   | 21+         | 12.0+       | 1.8+           | 1.4+            |
+| 1.0.1   | 21+         | 12.0+       | 1.8+           | 1.4+            |
 | 0.9.0   | 21+         | 12.0+       | 1.8+           | 1.4+            |
 | 0.8.0   | 21+         | N/A         | 1.8+           | 1.4+            |
 | 0.7.0   | 21+         | N/A         | 1.8+           | 1.4+            |
 
 ## Problemas Conocidos
 
-### Versión 1.0.0
+### Versión 1.0.1
 - **Problema**: Uso de memoria alto con fotos grandes
   - **Estado**: Arreglado en la próxima versión
   - **Solución temporal**: Usar compresión de imagen
@@ -283,7 +287,7 @@ y este proyecto sigue [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Versión 0.9.0
 - **Problema**: Inicialización de cámara lenta en algunos dispositivos
-  - **Estado**: Arreglado en 1.0.0
+  - **Estado**: Arreglado en 1.0.1
   - **Solución temporal**: Usar preferencia de captura FAST
 
 ### Versión 0.8.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-image selection on iOS: Implemented using `PHPickerViewController` (iOS 14+), replacing the old single-image picker.
 - New instrumented and unit tests: Added and re-enabled tests to cover new permission flows and multi-image selection.
 - Improved localization: New strings and translations for gallery permission dialogs.
+- **Configurable selection limit for gallery picker**: Added `selectionLimit` parameter to `GalleryConfig` to control the maximum number of images that can be selected in the gallery picker. The limit is enforced at compile time with a maximum value of 30 images to prevent performance issues and crashes when selecting too many images on iOS.
 
 ### Changed
 - Improved permission handling flow
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhanced image processing with automatic orientation correction for front camera photos
 - iOS gallery permission flow: Now requests permission directly via the system dialog, with no pre-permission custom dialog, matching native iOS behavior.
 - Refactored permission logic: Gallery and camera permission handling is now more consistent and cross-platform.
+- **Gallery selection limit**: Changed from unlimited selection (0) to configurable limit with maximum of 30 images to prevent performance issues and crashes on iOS when selecting too many images.
 
 ### Fixed
 - iOS permission denial flow
@@ -54,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dialog text errors: Gallery permission dialog no longer shows camera texts.
 - Multi-image selection bugs: Fixed performance issues and crashes when selecting many images on iOS.
 - Threading and casting errors: Resolved concurrency and type conversion issues in image selection.
+- **iOS gallery performance issues**: Fixed crashes and performance degradation when selecting more than 30 images by implementing a configurable selection limit with compile-time validation.
 
 ### Documentation
 
@@ -63,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All examples and guides updated to reflect new automatic permission handling and multi-image selection on iOS.
 - Added notes on platform differences for permission and selection behavior (Android vs iOS).
 
-## [1.0.0] - 2025-01-15
+## [1.0.1] - 2025-01-15
 
 ### Added
 - **First Official Release** of ImagePickerKMP
@@ -140,7 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Version History
 
-### Version 1.0.0 (Current Stable)
+### Version 1.0.1 (Current Stable)
 - **Release Date**: January 15, 2024
 - **Status**: Stable
 - **Key Features**:
@@ -177,7 +180,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Migration Guide
 
-### From 0.9.0 to 1.0.0
+### From 0.9.0 to 1.0.1
 
 #### Breaking Changes
 - Updated permission handling API
@@ -191,7 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    implementation("io.github.ismoy:imagepickerkmp:0.9.0")
    
    // New
-   implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+   implementation("io.github.ismoy:imagepickerkmp:1.0.1")
    ```
 
 2. **Update Permission Handling**
@@ -275,14 +278,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Android API | iOS Version | Kotlin Version | Compose Version |
 |---------|-------------|-------------|----------------|-----------------|
-| 1.0.0   | 21+         | 12.0+       | 1.8+           | 1.4+            |
+| 1.0.1   | 21+         | 12.0+       | 1.8+           | 1.4+            |
 | 0.9.0   | 21+         | 12.0+       | 1.8+           | 1.4+            |
 | 0.8.0   | 21+         | N/A         | 1.8+           | 1.4+            |
 | 0.7.0   | 21+         | N/A         | 1.8+           | 1.4+            |
 
 ## Known Issues
 
-### Version 1.0.0
+### Version 1.0.1
 - **Issue**: Memory usage high with large photos
   - **Status**: Fixed in next release
   - **Workaround**: Use image compression
@@ -293,7 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Version 0.9.0
 - **Issue**: Camera initialization slow on some devices
-  - **Status**: Fixed in 1.0.0
+  - **Status**: Fixed in 1.0.1
   - **Workaround**: Use FAST capture preference
 
 ### Version 0.8.0

--- a/docs/CONTRIBUTING.es.md
+++ b/docs/CONTRIBUTING.es.md
@@ -394,7 +394,7 @@ Lo que realmente pasó
 
 ## Entorno
 - Plataforma: Android/iOS
-- Versión: 1.0.0
+- Versión: 1.0.1
 - Dispositivo: Pixel 6 / iPhone 13
 - Versión OS: Android 12 / iOS 15
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -386,7 +386,7 @@ What actually happened
 
 ## Environment
 - Platform: Android/iOS
-- Version: 1.0.0
+- Version: 1.0.1
 - Device: Pixel 6 / iPhone 13
 - OS Version: Android 12 / iOS 15
 

--- a/docs/EXAMPLES.es.md
+++ b/docs/EXAMPLES.es.md
@@ -286,6 +286,67 @@ fun MultipleGallerySelectionExample() {
 }
 ```
 
+### Selección Múltiple Limitada
+
+```kotlin
+@Composable
+fun LimitedGallerySelectionExample() {
+    var showGallery by remember { mutableStateOf(false) }
+
+    if (showGallery) {
+        ImagePickerLauncher(
+            context = LocalContext.current,
+            config = ImagePickerConfig(
+                onPhotoCaptured = { result -> showGallery = false },
+                onPhotosSelected = { results -> showGallery = false },
+                onError = { exception -> showGallery = false },
+                cameraCaptureConfig = CameraCaptureConfig(
+                    galleryConfig = GalleryConfig(
+                        allowMultiple = true,
+                        mimeTypes = listOf("image/jpeg", "image/png"),
+                        selectionLimit = 10 // Permitir hasta 10 imágenes
+                    )
+                )
+            )
+        )
+    }
+
+    Button(onClick = { showGallery = true }) {
+        Text("Seleccionar hasta 10 imágenes")
+    }
+}
+```
+
+### Selección de Galería de Alto Rendimiento
+
+```kotlin
+@Composable
+fun HighPerformanceGalleryExample() {
+    var showGallery by remember { mutableStateOf(false) }
+
+    if (showGallery) {
+        ImagePickerLauncher(
+            context = LocalContext.current,
+            config = ImagePickerConfig(
+                onPhotoCaptured = { result -> showGallery = false },
+                onPhotosSelected = { results -> showGallery = false },
+                onError = { exception -> showGallery = false },
+                cameraCaptureConfig = CameraCaptureConfig(
+                    galleryConfig = GalleryConfig(
+                        allowMultiple = true,
+                        selectionLimit = 5 // Límite conservador para mejor rendimiento
+                    )
+                )
+            )
+        )
+    }
+
+    Button(onClick = { showGallery = true }) {
+        Text("Seleccionar hasta 5 imágenes (Optimizado)")
+    }
+}
+```
+
 - En **Android**, el usuario verá el selector de galería del sistema y los permisos se solicitan automáticamente si es necesario.
 - En **iOS**, se usa el selector nativo de galería. En iOS 14+ se soporta selección múltiple. El sistema gestiona permisos y acceso limitado de forma nativa.
 - El callback `onPhotosSelected` siempre recibe una lista, incluso para selección simple.
@@ -466,7 +527,7 @@ fun CustomErrorMessagesExample() {
 ```kotlin
 // build.gradle.kts (nivel de app)
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
     implementation("androidx.compose.ui:ui:1.4.0")
     implementation("androidx.compose.material:material:1.4.0")
     implementation("androidx.activity:activity-compose:1.7.0")
@@ -938,7 +999,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+                implementation("io.github.ismoy:imagepickerkmp:1.0.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
                 implementation("org.jetbrains.compose.runtime:runtime:1.4.0")
             }

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -274,6 +274,67 @@ fun MultipleGallerySelectionExample() {
 }
 ```
 
+### Limited Multiple Image Selection
+
+```kotlin
+@Composable
+fun LimitedGallerySelectionExample() {
+    var showGallery by remember { mutableStateOf(false) }
+
+    if (showGallery) {
+        ImagePickerLauncher(
+            context = LocalContext.current,
+            config = ImagePickerConfig(
+                onPhotoCaptured = { result -> showGallery = false },
+                onPhotosSelected = { results -> showGallery = false },
+                onError = { exception -> showGallery = false },
+                cameraCaptureConfig = CameraCaptureConfig(
+                    galleryConfig = GalleryConfig(
+                        allowMultiple = true,
+                        mimeTypes = listOf("image/jpeg", "image/png"),
+                        selectionLimit = 10 // Allow up to 10 images
+                    )
+                )
+            )
+        )
+    }
+
+    Button(onClick = { showGallery = true }) {
+        Text("Select Up to 10 Images")
+    }
+}
+```
+
+### High-Performance Gallery Selection
+
+```kotlin
+@Composable
+fun HighPerformanceGalleryExample() {
+    var showGallery by remember { mutableStateOf(false) }
+
+    if (showGallery) {
+        ImagePickerLauncher(
+            context = LocalContext.current,
+            config = ImagePickerConfig(
+                onPhotoCaptured = { result -> showGallery = false },
+                onPhotosSelected = { results -> showGallery = false },
+                onError = { exception -> showGallery = false },
+                cameraCaptureConfig = CameraCaptureConfig(
+                    galleryConfig = GalleryConfig(
+                        allowMultiple = true,
+                        selectionLimit = 5 // Conservative limit for better performance
+                    )
+                )
+            )
+        )
+    }
+
+    Button(onClick = { showGallery = true }) {
+        Text("Select Up to 5 Images (Optimized)")
+    }
+}
+```
+
 - On **Android**, the user will see the system gallery picker, and permissions are requested automatically if needed.
 - On **iOS**, the native gallery picker is used. On iOS 14+, multiple selection is supported. The system handles permissions and limited access natively.
 - The callback `onPhotosSelected` always receives a list, even for single selection.
@@ -454,7 +515,7 @@ fun CustomErrorMessagesExample() {
 ```kotlin
 // build.gradle.kts (app level)
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
     implementation("androidx.compose.ui:ui:1.4.0")
     implementation("androidx.compose.material:material:1.4.0")
     implementation("androidx.activity:activity-compose:1.7.0")
@@ -926,7 +987,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+                implementation("io.github.ismoy:imagepickerkmp:1.0.1")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.0")
                 implementation("org.jetbrains.compose.runtime:runtime:1.4.0")
             }

--- a/docs/FAQ.es.md
+++ b/docs/FAQ.es.md
@@ -76,7 +76,7 @@ Agrega la dependencia en tu `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -74,7 +74,7 @@ Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 

--- a/docs/INTEGRATION_GUIDE.es.md
+++ b/docs/INTEGRATION_GUIDE.es.md
@@ -35,7 +35,7 @@ En tu `build.gradle.kts` (nivel app):
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 
@@ -317,7 +317,7 @@ Para apps de Android usando Jetpack Compose:
 ```kotlin
 // build.gradle.kts (nivel de app)
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
     implementation("androidx.compose.ui:ui:1.4.0")
     implementation("androidx.compose.material:material:1.4.0")
 }
@@ -479,7 +479,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+                implementation("io.github.ismoy:imagepickerkmp:1.0.1")
             }
         }
     }

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -33,7 +33,7 @@ In your `build.gradle.kts` (app level):
 
 ```kotlin
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
 }
 ```
 
@@ -178,7 +178,7 @@ For Android apps using Jetpack Compose:
 ```kotlin
 // build.gradle.kts (app level)
 dependencies {
-    implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+    implementation("io.github.ismoy:imagepickerkmp:1.0.1")
     implementation("androidx.compose.ui:ui:1.4.0")
     implementation("androidx.compose.material:material:1.4.0")
 }
@@ -340,7 +340,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("io.github.ismoy:imagepickerkmp:1.0.0")
+                implementation("io.github.ismoy:imagepickerkmp:1.0.1")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -230,7 +230,7 @@ mavenPublishing{
     coordinates(
         groupId = "io.github.ismoy",
         artifactId = "imagepickerkmp",
-        version = "1.0.0"
+        version = "1.0.1"
     )
     pom {
         name.set("ImagePickerKMP")

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.android.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.android.kt
@@ -16,14 +16,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-@Suppress("ReturnCount")
+@Suppress("ReturnCount","LongParameterList")
 @Composable
 actual fun GalleryPickerLauncher(
     context: Any?,
     onPhotosSelected: (List<PhotoResult>) -> Unit,
     onError: (Exception) -> Unit,
     allowMultiple: Boolean,
-    mimeTypes: List<String>
+    mimeTypes: List<String>,
+    selectionLimit: Long
 ) {
     if (context !is ComponentActivity) {
         onError(Exception(getStringResource(StringResource.INVALID_CONTEXT_ERROR)))

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.kt
@@ -3,12 +3,16 @@ package io.github.ismoy.imagepickerkmp
 
 import androidx.compose.runtime.Composable
 import io.github.ismoy.imagepickerkmp.GalleryPhotoHandler.PhotoResult
+import io.github.ismoy.imagepickerkmp.ImagePickerUiConstants.SELECTION_LIMIT
 
+@Suppress("LongParameterList")
 @Composable
 expect fun GalleryPickerLauncher(
     context: Any?,
     onPhotosSelected: (List<PhotoResult>) -> Unit,
     onError: (Exception) -> Unit,
     allowMultiple: Boolean = false,
-    mimeTypes: List<String> = listOf("image/*")
+    mimeTypes: List<String> = listOf("image/*"),
+    selectionLimit: Long = SELECTION_LIMIT
 )
+

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerConfig.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerConfig.kt
@@ -44,7 +44,8 @@ data class PermissionAndConfirmationConfig(
  */
 data class GalleryConfig(
     val allowMultiple: Boolean = false,
-    val mimeTypes: List<String> = listOf("image/*")
+    val mimeTypes: List<String> = listOf("image/*"),
+    val selectionLimit: Int = 30
 )
 
 @Suppress("EndOfSentenceFormat")

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerUiConstants.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerUiConstants.kt
@@ -43,4 +43,5 @@ object ImagePickerUiConstants {
     const val ORIENTATION_FLIP_VERTICAL_Y = -1f
     const val SYSTEM_VERSION_10 = 10.0
     const val DELAY_TO_TAKE_PHOTO = 60L
+    const val SELECTION_LIMIT = 30L
 }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.ios.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerLauncher.ios.kt
@@ -4,34 +4,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import io.github.ismoy.imagepickerkmp.GalleryPhotoHandler.PhotoResult
 
+@Suppress("LongParameterList")
 @Composable
 actual fun GalleryPickerLauncher(
     context: Any?,
     onPhotosSelected: (List<PhotoResult>) -> Unit,
     onError: (Exception) -> Unit,
     allowMultiple: Boolean,
-    mimeTypes: List<String>
+    mimeTypes: List<String>,
+    selectionLimit: Long
 ) {
     LaunchedEffect(Unit) {
         if (allowMultiple) {
-            // Para selección múltiple, PHPickerDelegate ya maneja múltiples imágenes
             val selectedImages = mutableListOf<PhotoResult>()
             GalleryPickerOrchestrator.launchGallery(
                 onPhotoSelected = { result ->
-
                     selectedImages.add(result)
-                    // Enviar la lista completa cada vez que se agrega una imagen
                     onPhotosSelected(selectedImages.toList())
                 },
                 onError = onError,
-                allowMultiple = true
+                allowMultiple = true,
+                selectionLimit = selectionLimit
             )
         } else {
-            // Para selección única
             GalleryPickerOrchestrator.launchGallery(
                 onPhotoSelected = { result -> onPhotosSelected(listOf(result)) },
                 onError = onError,
-                allowMultiple = false
+                allowMultiple = false,
+                selectionLimit = 1
             )
         }
     }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerOrchestrator.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/GalleryPickerOrchestrator.kt
@@ -1,6 +1,7 @@
 package io.github.ismoy.imagepickerkmp
 
 import io.github.ismoy.imagepickerkmp.GalleryPhotoHandler.PhotoResult
+import io.github.ismoy.imagepickerkmp.ImagePickerUiConstants.SELECTION_LIMIT
 
 /**
  * Orchestrates the presentation and handling of the gallery picker on iOS.
@@ -11,7 +12,8 @@ object GalleryPickerOrchestrator {
     fun launchGallery(
         onPhotoSelected: (PhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        allowMultiple: Boolean = false
+        allowMultiple: Boolean = false,
+        selectionLimit: Long = SELECTION_LIMIT
     ) {
         try {
             val rootViewController = ViewControllerProvider.getRootViewController()
@@ -20,7 +22,7 @@ object GalleryPickerOrchestrator {
                 return
             }
             if (allowMultiple) {
-                PHPickerPresenter.presentGallery(rootViewController, onPhotoSelected, onError)
+                PHPickerPresenter.presentGallery(rootViewController, onPhotoSelected, onError, selectionLimit)
             } else {
                 GalleryPresenter.presentGallery(rootViewController, onPhotoSelected, onError)
             }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/PHPickerPresenter.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/PHPickerPresenter.kt
@@ -1,6 +1,7 @@
 package io.github.ismoy.imagepickerkmp
 
 import io.github.ismoy.imagepickerkmp.GalleryPhotoHandler.PhotoResult
+import io.github.ismoy.imagepickerkmp.ImagePickerUiConstants.SELECTION_LIMIT
 import platform.PhotosUI.PHPickerConfiguration
 import platform.PhotosUI.PHPickerFilter
 import platform.PhotosUI.PHPickerViewController
@@ -17,10 +18,12 @@ object PHPickerPresenter {
     fun presentGallery(
         viewController: UIViewController,
         onPhotoSelected: (PhotoResult) -> Unit,
-        onError: (Exception) -> Unit
+        onError: (Exception) -> Unit,
+        selectionLimit: Long
     ) {
+        require(selectionLimit <= SELECTION_LIMIT) {"Selection limit cannot exceed $SELECTION_LIMIT"}
         try {
-            val pickerViewController = createPHPickerController(onPhotoSelected, onError)
+            val pickerViewController = createPHPickerController(onPhotoSelected, onError, selectionLimit)
             viewController.presentViewController(pickerViewController,
                 animated = true, completion = null)
         } catch (e: Exception) {
@@ -30,10 +33,11 @@ object PHPickerPresenter {
 
     private fun createPHPickerController(
         onPhotoSelected: (PhotoResult) -> Unit,
-        onError: (Exception) -> Unit
+        onError: (Exception) -> Unit,
+        selectionLimit: Long
     ): PHPickerViewController {
         val configuration = PHPickerConfiguration()
-        configuration.selectionLimit = 0
+        configuration.selectionLimit = selectionLimit
         configuration.filter = PHPickerFilter.imagesFilter
 
         val cleanup = { pickerDelegate = null }


### PR DESCRIPTION
This commit introduces a `selectionLimit` parameter to `GalleryConfig` to control the maximum number of images that can be selected from the gallery.

- The `selectionLimit` defaults to 30 and has a maximum value of 30.
- This limit is enforced at compile time to prevent performance issues and crashes, particularly on iOS, when selecting a large number of images.
- The `GalleryPickerLauncher` now accepts `selectionLimit`.
- iOS implementation (`PHPickerPresenter`) now uses the provided `selectionLimit` and includes a `require` check.
- Documentation (README, CHANGELOG, FAQ, EXAMPLES, API_REFERENCE) has been updated to reflect this new feature, including examples and explanations.
- Version bumped to 1.0.1.
- GitHub Actions workflows for version bump and deployment are now set to manual trigger (`workflow_dispatch`).