### PR TITLE
feat: Convert fileSize from bytes to KB across all platforms

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -51,6 +51,11 @@
 ## Acerca de ImagePickerKMP
 - **Multiplataforma**: Funciona perfectamente en Android e iOS
 - **Integración de Cámara**: Acceso directo a la cámara con captura de fotos
+- **Selección de Galería**: Selecciona imágenes de la galería del dispositivo con soporte de compresión
+- **Compresión Automática de Imágenes**: Optimiza el tamaño de imagen manteniendo la calidad
+- **Niveles de Compresión Configurables**: Opciones de compresión BAJA, MEDIA, ALTA
+- **Procesamiento Asíncrono**: UI no bloqueante con integración de Kotlin Coroutines
+- **Soporte de Múltiples Formatos**: JPEG, PNG, HEIC, HEIF, WebP, GIF, BMP
 - **UI Personalizable**: Diálogos personalizados y vistas de confirmación
 - **Manejo de Permisos**: Gestión inteligente de permisos para ambas plataformas
 - **Fácil Integración**: API simple con Compose Multiplatform
@@ -133,6 +138,62 @@ Button(onClick = { showGallery = true }) {
     Text("Elegir de la Galería")
 }
 ```
+
+## Compresión de Imágenes
+**Optimiza automáticamente el tamaño de imagen manteniendo la calidad con niveles de compresión configurables.**
+
+### Niveles de Compresión
+- **BAJA (LOW)**: 95% calidad, máx 2560px dimensión - Mejor calidad, archivos más grandes
+- **MEDIA (MEDIUM)**: 75% calidad, máx 1920px dimensión - Calidad/tamaño equilibrado
+- **ALTA (HIGH)**: 50% calidad, máx 1280px dimensión - Archivos más pequeños, bueno para almacenamiento
+
+### Cámara con Compresión
+```kotlin
+if (showCamera) {
+    ImagePickerLauncher(
+        config = ImagePickerConfig(
+            onPhotoCaptured = { result ->
+                capturedPhoto = result
+                showCamera = false
+            },
+            onError = { showCamera = false },
+            onDismiss = { showCamera = false },
+            cameraCaptureConfig = CameraCaptureConfig(
+                compressionLevel = CompressionLevel.MEDIUM // Habilitar compresión
+            )
+        )
+    )
+}
+```
+
+### Galería con Compresión
+```kotlin
+if (showGallery) {
+    GalleryPickerLauncher(
+        onPhotosSelected = { photos ->
+            selectedImages = photos
+            showGallery = false
+        },
+        onError = { showGallery = false },
+        onDismiss = { showGallery = false },
+        allowMultiple = true,
+        mimeTypes = listOf(MimeType.IMAGE_JPEG, MimeType.IMAGE_PNG),
+        cameraCaptureConfig = CameraCaptureConfig(
+            compressionLevel = CompressionLevel.HIGH // Optimizar para almacenamiento
+        )
+    )
+}
+```
+
+### Formatos de Imagen Soportados
+- **JPEG** (image/jpeg) - Soporte completo de compresión
+- **PNG** (image/png) - Soporte completo de compresión
+- **HEIC** (image/heic) - Soporte completo de compresión
+- **HEIF** (image/heif) - Soporte completo de compresión
+- **WebP** (image/webp) - Soporte completo de compresión
+- **GIF** (image/gif) - Soporte completo de compresión
+- **BMP** (image/bmp) - Soporte completo de compresión
+
 ### Para más personalización (vistas de confirmación, filtrado MIME, etc.), [consulta la guía de integración para KMP.](https://github.com/ismoy/ImagePickerKMP/blob/main/docs/INTEGRATION_GUIDE.es.md)
 
 ### Usando ImagePickerKMP en Android Nativo (Jetpack Compose)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@
 ## About ImagePickerKMP
 - **Cross-platform**: Works seamlessly on Android and iOS
 - **Camera Integration**: Direct camera access with photo capture
+- **Gallery Selection**: Pick images from device gallery with compression support
+- **Automatic Image Compression**: Optimize image size while maintaining quality
+- **Configurable Compression Levels**: LOW, MEDIUM, HIGH compression options
+- **Async Processing**: Non-blocking UI with Kotlin Coroutines integration
+- **Multiple Format Support**: JPEG, PNG, HEIC, HEIF, WebP, GIF, BMP
 - **Customizable UI**: Custom dialogs and confirmation views
 - **Permission Handling**: Smart permission management for both platforms
 - **Easy Integration**: Simple API with Compose Multiplatform
@@ -92,6 +97,9 @@ if (showCamera) {
         config = ImagePickerConfig(
             onPhotoCaptured = { result ->
                 capturedPhoto = result
+                // Now you can access result.fileSize for camera captures too!
+                val fileSizeKB = (result.fileSize ?: 0) / 1024
+                println("Camera photo size: ${fileSizeKB}KB")
                 showCamera = false
             },
             onError = {
@@ -133,6 +141,68 @@ Button(onClick = { showGallery = true }) {
     Text("Choose from Gallery")
 }
 ```
+
+## Image Compression
+**Automatically optimize image size while maintaining quality with configurable compression levels.**
+
+### Compression Levels
+- **LOW**: 95% quality, max 2560px dimension - Best quality, larger files
+- **MEDIUM**: 75% quality, max 1920px dimension - Balanced quality/size 
+- **HIGH**: 50% quality, max 1280px dimension - Smaller files, good for storage
+
+### Camera with Compression
+```kotlin
+if (showCamera) {
+    ImagePickerLauncher(
+        config = ImagePickerConfig(
+            onPhotoCaptured = { result ->
+                capturedPhoto = result
+                val fileSizeKB = (result.fileSize ?: 0) / 1024
+                println("Compressed camera photo: ${fileSizeKB}KB")
+                showCamera = false
+            },
+            onError = { showCamera = false },
+            onDismiss = { showCamera = false },
+            cameraCaptureConfig = CameraCaptureConfig(
+                compressionLevel = CompressionLevel.MEDIUM // Enable compression
+            )
+        )
+    )
+}
+```
+
+### Gallery with Compression
+```kotlin
+if (showGallery) {
+    GalleryPickerLauncher(
+        onPhotosSelected = { photos ->
+            photos.forEach { photo ->
+                val fileSizeKB = (photo.fileSize ?: 0) / 1024
+                println("Gallery photo: ${photo.fileName} - ${fileSizeKB}KB")
+            }
+            selectedImages = photos
+            showGallery = false
+        },
+        onError = { showGallery = false },
+        onDismiss = { showGallery = false },
+        allowMultiple = true,
+        mimeTypes = listOf(MimeType.IMAGE_JPEG, MimeType.IMAGE_PNG),
+        cameraCaptureConfig = CameraCaptureConfig(
+            compressionLevel = CompressionLevel.HIGH // Optimize for storage
+        )
+    )
+}
+```
+
+### Supported Image Formats
+- **JPEG** (image/jpeg) - Full compression support
+- **PNG** (image/png) - Full compression support  
+- **HEIC** (image/heic) - Full compression support
+- **HEIF** (image/heif) - Full compression support
+- **WebP** (image/webp) - Full compression support
+- **GIF** (image/gif) - Full compression support
+- **BMP** (image/bmp) - Full compression support
+
 ### For more customization (confirmation views, MIME filtering, etc.), [check out the integration guide for KMP.](https://github.com/ismoy/ImagePickerKMP/blob/main/docs/INTEGRATION_GUIDE.md)
 
 ### Using ImagePickerKMP in Android Native (Jetpack Compose)
@@ -196,9 +266,81 @@ if (showGallery) {
 
 Button(onClick = { showGallery = true }) {
     Text("Choose from Gallery")
+Button(onClick = { showGallery = true }) {
+    Text("Choose from Gallery")
+}
+```
+
+### Android Native with Compression
+```kotlin
+// Camera with compression
+if (showCamera) {
+    ImagePickerLauncher(
+        config = ImagePickerConfig(
+            onPhotoCaptured = { result ->
+                capturedPhoto = result
+                val fileSizeKB = (result.fileSize ?: 0) / 1024
+                println("Camera photo compressed to: ${fileSizeKB}KB")
+                showCamera = false
+            },
+            onError = { showCamera = false },
+            onDismiss = { showCamera = false },
+            cameraCaptureConfig = CameraCaptureConfig(
+                compressionLevel = CompressionLevel.MEDIUM
+            )
+        )
+    )
+}
+
+// Gallery with compression
+if (showGallery) {
+    GalleryPickerLauncher(
+        onPhotosSelected = { photos ->
+            photos.forEach { photo ->
+                val fileSizeKB = (photo.fileSize ?: 0) / 1024
+                println("${photo.fileName}: ${fileSizeKB}KB")
+            }
+            selectedImages = photos
+            showGallery = false
+        },
+        onError = { showGallery = false },
+        onDismiss = { showGallery = false },
+        allowMultiple = true,
+        mimeTypes = listOf(MimeType.IMAGE_JPEG, MimeType.IMAGE_PNG),
+        cameraCaptureConfig = CameraCaptureConfig(
+            compressionLevel = CompressionLevel.HIGH
+        )
+    )
 }
 ```
 ### For more customization (confirmation views, MIME filtering, etc.), [check out the integration guide for Native.](https://github.com/ismoy/ImagePickerKMP/blob/main/docs/INTEGRATION_GUIDE.md)
+
+## File Size Utilities
+
+### Converting Bytes to Readable Format
+```kotlin
+// Extension function for cleaner file size display
+fun Long?.toReadableFileSize(): String {
+    if (this == null || this == 0L) return "Unknown size"
+    
+    return when {
+        this < 1024 -> "${this}B"
+        this < 1024 * 1024 -> "${this / 1024}KB"
+        else -> "${"%.1f".format(this / (1024.0 * 1024.0))}MB"
+    }
+}
+
+// Usage examples:
+onPhotoCaptured = { result ->
+    println("Camera photo: ${result.fileSize.toReadableFileSize()}")
+}
+
+onPhotosSelected = { photos ->
+    photos.forEach { photo ->
+        println("${photo.fileName}: ${photo.fileSize.toReadableFileSize()}")
+    }
+}
+```
 
 ## Platform Support
 <p align="center">

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **🗜️ Automatic Image Compression**: Complete compression system for both camera and gallery
+  - **Configurable Compression Levels**: LOW (95% quality, 2560px), MEDIUM (75% quality, 1920px), HIGH (50% quality, 1280px)
+  - **Multi-format Support**: JPEG, PNG, HEIC, HEIF, WebP, GIF, BMP compression
+  - **Async Processing**: Non-blocking UI with Kotlin Coroutines integration
+  - **Smart Optimization**: Combines dimension scaling + quality compression
+  - **Memory Efficient**: Automatic bitmap recycling and cleanup
+  - **Unified API**: Same compression logic for camera capture and gallery selection
+  - **Cross-platform**: Works on both Android and iOS
+  - **Performance Optimized**: Background processing with proper thread management
+
+### Changed
+
+- Updated `CameraCaptureConfig` with new `compressionLevel: CompressionLevel?` parameter
+- Enhanced `GalleryPickerLauncher` to support compression through `cameraCaptureConfig`
+- Improved image processing pipeline with unified compression architecture
+- Updated documentation with comprehensive compression examples and guides
+
+### Fixed
+
+- Fixed inverted compression logic (HIGH compression now produces smaller files as expected)
+- Corrected image scaling algorithm for consistent quality across compression levels
+- Resolved CompressionConfig test failures by excluding IMAGE_ALL wildcard from supported formats
+
 ## [1.0.22] - 2024-12-XX
 
 ### Added

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -427,7 +427,7 @@ mavenPublishing{
     coordinates(
         groupId = "io.github.ismoy",
         artifactId = "imagepickerkmp",
-        version = "1.0.24"
+        version = "1.0.23-beta-3"
     )
     pom {
         name.set("ImagePickerKMP")

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/camera/CameraXManager.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/camera/CameraXManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.camera.view.PreviewView
 import io.github.ismoy.imagepickerkmp.data.processors.ImageProcessor
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
 
@@ -35,11 +36,18 @@ class CameraXManager(
     }
     fun takePicture(
         onPhotoResult: (PhotoResult) -> Unit,
-        onError: (Exception) -> Unit
+        onError: (Exception) -> Unit,
+        compressionLevel: CompressionLevel? = null
     ){
         cameraController.takePicture(
             onImageCaptured = { imageFile, cameraType ->
-                imageProcessor.processImage(imageFile, cameraType, onPhotoResult, onError)
+                imageProcessor.processImage(
+                    imageFile = imageFile,
+                    cameraType = cameraType,
+                    compressionLevel = compressionLevel,
+                    onPhotoCaptured = onPhotoResult,
+                    onError = onError
+                )
             },
             onError = onError
         )

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/processors/ImageProcessor.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/processors/ImageProcessor.kt
@@ -1,14 +1,17 @@
 package io.github.ismoy.imagepickerkmp.data.processors
 
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import io.github.ismoy.imagepickerkmp.data.camera.CameraController.CameraType
 import io.github.ismoy.imagepickerkmp.domain.exceptions.ImageProcessingException
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Handles image processing operations such as orientation correction and photo result creation.
@@ -24,19 +27,48 @@ class ImageProcessor(
     fun processImage(
         imageFile: File,
         cameraType: CameraType,
+        compressionLevel: CompressionLevel? = null,
         onPhotoCaptured: (PhotoResult) -> Unit,
         onError: (Exception) -> Unit
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val correctedImageFile = orientationCorrector.correctImageOrientation(imageFile, cameraType)
-                val bitmap = BitmapFactory.decodeFile(correctedImageFile.absolutePath)
-                if (bitmap != null) {
+                val originalBitmap = BitmapFactory.decodeFile(correctedImageFile.absolutePath)
+                
+                if (originalBitmap != null) {
+                    val processedBitmap = if (compressionLevel != null) {
+                        processImageWithCompression(originalBitmap, compressionLevel)
+                    } else {
+                        originalBitmap
+                    }
+                    
+                    val finalFile = if (compressionLevel != null) {
+                        logDebug("Applying compression level: $compressionLevel")
+                        saveCompressedImage(processedBitmap, correctedImageFile, compressionLevel)
+                    } else {
+                        logDebug("No compression applied")
+                        correctedImageFile
+                    }
+                    
+                    val fileSizeInBytes = finalFile.length()
+                    val fileSizeInKB = bytesToKB(fileSizeInBytes)
                     val result = PhotoResult(
-                        uri = fileManager.fileToUriString(correctedImageFile),
-                        width = bitmap.width,
-                        height = bitmap.height
+                        uri = fileManager.fileToUriString(finalFile),
+                        width = processedBitmap.width,
+                        height = processedBitmap.height,
+                        fileName = finalFile.name,
+                        fileSize = fileSizeInKB
                     )
+                    
+                    logDebug("Image processed successfully - File size: ${fileSizeInKB}KB (${fileSizeInBytes} bytes)")
+                    
+                    // Clean up bitmaps
+                    if (processedBitmap != originalBitmap) {
+                        originalBitmap.recycle()
+                    }
+                    processedBitmap.recycle()
+                    
                     withContext(Dispatchers.Main) {
                         onPhotoCaptured(result)
                     }
@@ -51,5 +83,55 @@ class ImageProcessor(
                 }
             }
         }
+    }
+    
+    private fun processImageWithCompression(
+        bitmap: Bitmap,
+        compressionLevel: CompressionLevel
+    ): Bitmap {
+        // Correct logic: HIGH compression = smaller image, LOW compression = larger image
+        val maxDimension = when (compressionLevel) {
+            CompressionLevel.HIGH -> 1280  // Más compresión = imagen más pequeña
+            CompressionLevel.MEDIUM -> 1920 // Compresión media
+            CompressionLevel.LOW -> 2560   // Menos compresión = imagen más grande
+        }
+        
+        val currentMaxDimension = maxOf(bitmap.width, bitmap.height)
+        
+        return if (currentMaxDimension > maxDimension) {
+            val scale = maxDimension.toFloat() / currentMaxDimension.toFloat()
+            val targetWidth = (bitmap.width * scale).toInt()
+            val targetHeight = (bitmap.height * scale).toInt()
+            
+            val resizedBitmap = Bitmap.createScaledBitmap(bitmap, targetWidth, targetHeight, true)
+            if (resizedBitmap != bitmap) {
+                bitmap.recycle()
+            }
+            resizedBitmap
+        } else {
+            bitmap
+        }
+    }
+    
+    private fun saveCompressedImage(
+        bitmap: Bitmap,
+        originalFile: File,
+        compressionLevel: CompressionLevel
+    ): File {
+        val outputFile = File(originalFile.parentFile, "compressed_${originalFile.name}")
+        val quality = (compressionLevel.toQualityValue() * 100).toInt()
+        
+        FileOutputStream(outputFile).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, quality, outputStream)
+        }
+        
+        return outputFile
+    }
+
+    // Utility functions for better code practices
+    private fun bytesToKB(bytes: Long): Long = maxOf(1L, bytes / 1024)
+
+    private fun logDebug(message: String) {
+        println("🔧 Android ImageProcessor: $message")
     }
 }

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCaptureStateHolder.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCaptureStateHolder.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import io.github.ismoy.imagepickerkmp.data.camera.CameraController
 import io.github.ismoy.imagepickerkmp.data.camera.CameraXManager
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.DELAY_TO_TAKE_PHOTO
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
@@ -85,10 +86,11 @@ class CameraCaptureStateHolder(
 
     fun capturePhoto(
         onPhotoResult: (PhotoResult) -> Unit,
-        onError: (Exception) -> Unit
+        onError: (Exception) -> Unit,
+        compressionLevel: CompressionLevel? = null
     ) {
         showFlashOverlay = true
-        cameraManager.takePicture(onPhotoResult, onError)
+        cameraManager.takePicture(onPhotoResult, onError, compressionLevel)
         coroutineScope.launch {
             delay(DELAY_TO_TAKE_PHOTO)
             showFlashOverlay = false

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import io.github.ismoy.imagepickerkmp.data.camera.CameraXManager
-import io.github.ismoy.imagepickerkmp.domain.models.MimeType
 import io.github.ismoy.imagepickerkmp.domain.config.CameraCaptureConfig
 import io.github.ismoy.imagepickerkmp.domain.config.CameraPreviewConfig
 import io.github.ismoy.imagepickerkmp.domain.config.PermissionConfig
@@ -142,7 +141,8 @@ private fun CameraAndPreview(
             captureButtonSize = cameraCaptureConfig.captureButtonSize,
             uiConfig = cameraCaptureConfig.uiConfig,
             cameraCallbacks = cameraCaptureConfig.cameraCallbacks
-        )
+        ),
+        compressionLevel = cameraCaptureConfig.compressionLevel
     )
 }
 

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/CompressionConfig.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/CompressionConfig.kt
@@ -1,0 +1,39 @@
+package io.github.ismoy.imagepickerkmp.domain.config
+
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
+import io.github.ismoy.imagepickerkmp.domain.models.MimeType
+
+/**
+ * Configuration for automatic image compression.
+ *
+ * @property enabled Whether automatic compression is enabled
+ * @property compressionLevel The level of compression to apply
+ * @property maxWidth Maximum width in pixels (null for no limit)
+ * @property maxHeight Maximum height in pixels (null for no limit)
+ * @property customQuality Custom quality value (0.0 to 1.0), overrides compressionLevel if set
+ * @property maintainAspectRatio Whether to maintain aspect ratio when resizing
+ * @property supportedFormats List of MIME types that support compression (defaults to all supported image formats)
+ */
+data class CompressionConfig(
+    val enabled: Boolean = false,
+    val compressionLevel: CompressionLevel = CompressionLevel.MEDIUM,
+    val maxWidth: Int? = null,
+    val maxHeight: Int? = null,
+    val customQuality: Double? = null,
+    val maintainAspectRatio: Boolean = true,
+    val supportedFormats: List<MimeType> = MimeType.ALL_SUPPORTED_TYPES.filter { it != MimeType.IMAGE_ALL }
+) {
+    /**
+     * Gets the effective quality value, prioritizing customQuality over compressionLevel
+     */
+    fun getQuality(): Double {
+        return customQuality ?: compressionLevel.toQualityValue()
+    }
+
+    /**
+     * Checks if the given format supports compression
+     */
+    fun supportsFormat(mimeType: String): Boolean {
+        return supportedFormats.any { it.value.equals(mimeType, ignoreCase = true) }
+    }
+}

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
 import io.github.ismoy.imagepickerkmp.domain.models.MimeType
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
@@ -61,6 +62,7 @@ data class GalleryConfig(
 data class CameraCaptureConfig(
     val preference: CapturePhotoPreference = CapturePhotoPreference.QUALITY,
     val captureButtonSize: Dp = 72.dp,
+    val compressionLevel: CompressionLevel? = null, // null = no compression, MEDIUM = recommended
     val uiConfig: UiConfig = UiConfig(),
     val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
     val permissionAndConfirmationConfig: PermissionAndConfirmationConfig = PermissionAndConfirmationConfig(),

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/CompressionLevel.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/CompressionLevel.kt
@@ -1,0 +1,25 @@
+package io.github.ismoy.imagepickerkmp.domain.models
+
+/**
+ * Enum representing different compression levels for image processing.
+ *
+ * @property LOW Low compression - maintains high quality but larger file size
+ * @property MEDIUM Medium compression - balanced quality and file size
+ * @property HIGH High compression - smaller file size but lower quality
+ */
+enum class CompressionLevel {
+    LOW,
+    MEDIUM,
+    HIGH;
+
+    /**
+     * Converts compression level to quality value (0.0 to 1.0)
+     */
+    fun toQualityValue(): Double {
+        return when (this) {
+            LOW -> 0.95
+            MEDIUM -> 0.75
+            HIGH -> 0.50
+        }
+    }
+}

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/GalleryPhotoResult.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/GalleryPhotoResult.kt
@@ -7,7 +7,7 @@ package io.github.ismoy.imagepickerkmp.domain.models
  * @property width The width of the photo in pixels.
  * @property height The height of the photo in pixels.
  * @property fileName The name of the file, if available.
- * @property fileSize The size of the file in bytes, if available.
+ * @property fileSize The size of the file in KB, if available.
  */
 data class GalleryPhotoResult(
     val uri: String,

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/PhotoResult.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/PhotoResult.kt
@@ -6,9 +6,13 @@ package io.github.ismoy.imagepickerkmp.domain.models
  * @property uri The URI of the captured photo as a string.
  * @property width The width of the photo in pixels.
  * @property height The height of the photo in pixels.
+ * @property fileName The name of the file, if available.
+ * @property fileSize The size of the file in KB, if available.
  */
 data class PhotoResult(
     val uri: String,
     val width: Int,
     val height: Int,
+    val fileName: String? = null,
+    val fileSize: Long? = null
 )

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/utils/CompressionUtils.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/utils/CompressionUtils.kt
@@ -1,0 +1,102 @@
+package io.github.ismoy.imagepickerkmp.domain.utils
+
+import io.github.ismoy.imagepickerkmp.domain.config.CompressionConfig
+import kotlin.math.min
+
+/**
+ * Utility object for common image compression operations.
+ */
+object CompressionUtils {
+    
+    /**
+     * Calculates the optimal dimensions for an image based on compression configuration.
+     *
+     * @param originalWidth Original image width
+     * @param originalHeight Original image height
+     * @param config Compression configuration
+     * @return Pair of (width, height) for the resized image
+     */
+    fun calculateOptimalDimensions(
+        originalWidth: Int,
+        originalHeight: Int,
+        config: CompressionConfig
+    ): Pair<Int, Int> {
+        if (config.maxWidth == null && config.maxHeight == null) {
+            return Pair(originalWidth, originalHeight)
+        }
+
+        val aspectRatio = originalWidth.toFloat() / originalHeight.toFloat()
+        
+        return when {
+            config.maxWidth != null && config.maxHeight != null -> {
+                if (config.maintainAspectRatio) {
+                    val scaleWidth = config.maxWidth.toFloat() / originalWidth
+                    val scaleHeight = config.maxHeight.toFloat() / originalHeight
+                    val scale = min(scaleWidth, scaleHeight)
+                    
+                    if (scale < 1.0f) {
+                        Pair(
+                            (originalWidth * scale).toInt(),
+                            (originalHeight * scale).toInt()
+                        )
+                    } else {
+                        Pair(originalWidth, originalHeight)
+                    }
+                } else {
+                    Pair(
+                        min(originalWidth, config.maxWidth),
+                        min(originalHeight, config.maxHeight)
+                    )
+                }
+            }
+            config.maxWidth != null -> {
+                if (originalWidth > config.maxWidth) {
+                    val newHeight = (config.maxWidth / aspectRatio).toInt()
+                    Pair(config.maxWidth, newHeight)
+                } else {
+                    Pair(originalWidth, originalHeight)
+                }
+            }
+            config.maxHeight != null -> {
+                if (originalHeight > config.maxHeight) {
+                    val newWidth = (config.maxHeight * aspectRatio).toInt()
+                    Pair(newWidth, config.maxHeight)
+                } else {
+                    Pair(originalWidth, originalHeight)
+                }
+            }
+            else -> Pair(originalWidth, originalHeight)
+        }
+    }
+
+    /**
+     * Determines if compression should be applied based on the image format.
+     *
+     * @param mimeType The MIME type of the image
+     * @param config Compression configuration
+     * @return true if compression should be applied
+     */
+    fun shouldCompress(mimeType: String?, config: CompressionConfig): Boolean {
+        return config.enabled && mimeType != null && config.supportsFormat(mimeType)
+    }
+
+    /**
+     * Validates compression configuration values.
+     *
+     * @param config Compression configuration to validate
+     * @throws IllegalArgumentException if configuration is invalid
+     */
+    fun validateConfig(config: CompressionConfig) {
+        require(config.getQuality() in 0.0..1.0) {
+            "Quality must be between 0.0 and 1.0, got ${config.getQuality()}"
+        }
+        
+        config.maxWidth?.let { width ->
+            require(width > 0) { "Max width must be positive, got $width" }
+        }
+        
+        config.maxHeight?.let { height ->
+            require(height > 0) { "Max height must be positive, got $height" }
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/CompressionConfigAllFormatsTest.kt
+++ b/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/CompressionConfigAllFormatsTest.kt
@@ -1,0 +1,49 @@
+package io.github.ismoy.imagepickerkmp.domain.config
+
+import io.github.ismoy.imagepickerkmp.domain.models.MimeType
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Test to verify that CompressionConfig supports all available image formats by default
+ */
+class CompressionConfigAllFormatsTest {
+
+    @Test
+    fun `default compression config should support all image MIME types`() {
+        val defaultConfig = CompressionConfig()
+        
+        // Verify all individual image formats are supported
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_JPEG.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_PNG.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_WEBP.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_HEIC.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_HEIF.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_GIF.value))
+        assertTrue(defaultConfig.supportsFormat(MimeType.IMAGE_BMP.value))
+    }
+
+    @Test
+    fun `default config should have all supported MIME types count`() {
+        val defaultConfig = CompressionConfig()
+        
+        // Should have 7 specific image types (excluding IMAGE_ALL which is a wildcard)
+        val expectedCount = 7
+        assertTrue(
+            defaultConfig.supportedFormats.size == expectedCount,
+            "Expected $expectedCount formats, but got ${defaultConfig.supportedFormats.size}"
+        )
+    }
+
+    @Test
+    fun `custom config can still limit to specific formats`() {
+        val customConfig = CompressionConfig(
+            supportedFormats = listOf(MimeType.IMAGE_JPEG, MimeType.IMAGE_PNG)
+        )
+        
+        assertTrue(customConfig.supportsFormat(MimeType.IMAGE_JPEG.value))
+        assertTrue(customConfig.supportsFormat(MimeType.IMAGE_PNG.value))
+        assertTrue(!customConfig.supportsFormat(MimeType.IMAGE_WEBP.value))
+        assertTrue(!customConfig.supportsFormat(MimeType.IMAGE_HEIC.value))
+    }
+}

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/delegates/CameraDelegate.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/delegates/CameraDelegate.kt
@@ -2,11 +2,15 @@ package io.github.ismoy.imagepickerkmp.data.delegates
 
 import io.github.ismoy.imagepickerkmp.data.processors.ImageProcessor
 import io.github.ismoy.imagepickerkmp.domain.exceptions.PhotoCaptureException
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
 import platform.UIKit.UIImage
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerDelegateProtocol
 import platform.UIKit.UIImagePickerControllerOriginalImage
+import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UINavigationControllerDelegateProtocol
 import platform.darwin.NSObject
 
@@ -15,10 +19,12 @@ import platform.darwin.NSObject
  *
  * This class processes captured images and communicates results or errors to the caller.
  */
+@OptIn(ExperimentalForeignApi::class)
 class CameraDelegate(
     private val onPhotoCaptured: (PhotoResult) -> Unit,
     private val onError: (Exception) -> Unit,
-    private val onDismiss: () -> Unit
+    private val onDismiss: () -> Unit,
+    private val compressionLevel: CompressionLevel? = null
 ) : NSObject(), UIImagePickerControllerDelegateProtocol, UINavigationControllerDelegateProtocol {
 
     override fun imagePickerController(
@@ -41,16 +47,53 @@ class CameraDelegate(
 
     private fun processCapturedImage(image: UIImage, picker: UIImagePickerController) {
         try {
-            val photoResult = ImageProcessor.processImage(image, quality = 0.9)
-            onPhotoCaptured(photoResult)
+            logDebug("Processing captured image...")
+            logDebug("CompressionLevel received: $compressionLevel")
+            
+            val processedData = if (compressionLevel != null) {
+                logDebug("Using compression with level: $compressionLevel")
+                ImageProcessor.processImage(image, compressionLevel)
+            } else {
+                logDebug("No compression - using original quality")
+                UIImageJPEGRepresentation(image, 1.0)
+            }
+            
+            if (processedData != null) {
+                val tempURL = ImageProcessor.saveImageToTempDirectory(processedData)
+                if (tempURL != null) {
+                    val fileSizeInBytes = processedData.length.toLong()
+                    val fileSizeInKB = bytesToKB(fileSizeInBytes)
+                    val photoResult = PhotoResult(
+                        uri = tempURL.absoluteString ?: "",
+                        width = image.size.useContents { width.toInt() },
+                        height = image.size.useContents { height.toInt() },
+                        fileName = tempURL.lastPathComponent,
+                        fileSize = fileSizeInKB
+                    )
+                    logDebug("Final result - Image saved to: ${photoResult.uri}")
+                    logDebug("Final result - File size: ${fileSizeInKB}KB (${fileSizeInBytes} bytes)")
+                    onPhotoCaptured(photoResult)
+                } else {
+                    onError(PhotoCaptureException("Failed to save processed image"))
+                }
+            } else {
+                onError(PhotoCaptureException("Failed to process image"))
+            }
         } catch (e: Exception) {
+            logDebug("Error processing image: ${e.message}")
             onError(PhotoCaptureException("Failed to process image: ${e.message}"))
         } finally {
             dismissPicker(picker)
         }
     }
 
+    private fun bytesToKB(bytes: Long): Long = maxOf(1L, bytes / 1024)
+
+    private fun logDebug(message: String) {
+        println("iOS CameraDelegate: $message")
+    }
+
     private fun dismissPicker(picker: UIImagePickerController) {
-        picker.dismissViewControllerAnimated(true, completion = null)
+        picker.dismissViewControllerAnimated(true, null)
     }
 }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/orchestrators/GalleryPickerOrchestrator.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/orchestrators/GalleryPickerOrchestrator.kt
@@ -4,6 +4,7 @@ import io.github.ismoy.imagepickerkmp.presentation.presenters.GalleryPresenter
 import io.github.ismoy.imagepickerkmp.domain.utils.ViewControllerProvider
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.SELECTION_LIMIT
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.presentation.presenters.PHPickerPresenter
 
 /**
@@ -17,7 +18,8 @@ object GalleryPickerOrchestrator {
         onError: (Exception) -> Unit,
         onDismiss: () -> Unit,
         allowMultiple: Boolean = false,
-        selectionLimit: Long = SELECTION_LIMIT
+        selectionLimit: Long = SELECTION_LIMIT,
+        compressionLevel: CompressionLevel? = null
     ) {
         try {
             val rootViewController = ViewControllerProvider.getRootViewController()
@@ -31,10 +33,17 @@ object GalleryPickerOrchestrator {
                     onPhotoSelected,
                     onError,
                     onDismiss,
-                    selectionLimit
+                    selectionLimit,
+                    compressionLevel
                 )
             } else {
-                GalleryPresenter.presentGallery(rootViewController, onPhotoSelected, onError, onDismiss)
+                GalleryPresenter.presentGallery(
+                    rootViewController,
+                    onPhotoSelected,
+                    onError,
+                    onDismiss,
+                    compressionLevel
+                )
             }
         } catch (e: Exception) {
             onError(Exception("Failed to launch gallery: ${e.message}"))

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/orchestrators/PhotoCaptureOrchestrator.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/orchestrators/PhotoCaptureOrchestrator.kt
@@ -4,6 +4,7 @@ import io.github.ismoy.imagepickerkmp.presentation.presenters.CameraPresenter
 import io.github.ismoy.imagepickerkmp.domain.utils.ViewControllerProvider
 import io.github.ismoy.imagepickerkmp.domain.exceptions.PhotoCaptureException
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 
 /**
  * Orchestrates the presentation and handling of the camera interface on iOS.
@@ -14,7 +15,8 @@ object PhotoCaptureOrchestrator {
     fun launchCamera(
         onPhotoCaptured: (PhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: () -> Unit,
+        compressionLevel: CompressionLevel? = null
     ) {
         try {
             val rootViewController = ViewControllerProvider.getRootViewController()
@@ -22,7 +24,13 @@ object PhotoCaptureOrchestrator {
                 onError(PhotoCaptureException("Could not find root view controller"))
                 return
             }
-            CameraPresenter.presentCamera(rootViewController, onPhotoCaptured, onError, onDismiss)
+            CameraPresenter.presentCamera(
+                rootViewController,
+                onPhotoCaptured,
+                onError,
+                onDismiss,
+                compressionLevel
+            )
         } catch (e: Exception) {
             onError(PhotoCaptureException("Failed to launch camera: ${e.message}"))
         }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/processors/ImageProcessor.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/processors/ImageProcessor.kt
@@ -1,10 +1,11 @@
 package io.github.ismoy.imagepickerkmp.data.processors
 
-import io.github.ismoy.imagepickerkmp.domain.exceptions.PhotoCaptureException
-import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
-import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSNumber
@@ -12,83 +13,141 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
 import platform.Foundation.temporaryDirectory
 import platform.Foundation.writeToURL
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
+import platform.UIKit.drawInRect
 
 /**
- * Handles image processing operations for iOS, including conversion, saving, and result creation.
- *
- * Provides methods to process images from the camera or gallery, convert them to JPEG,
- * save them to disk, and return result data classes for use in the library.
+ * Handles image processing operations for iOS, including compression and conversion.
  */
 @OptIn(ExperimentalForeignApi::class)
 object ImageProcessor {
 
-    fun processImage(image: UIImage, quality: Double = 0.9): PhotoResult {
-        val jpegData = convertToJPEG(image, quality)
-        val fileURL = saveImageToDisk(jpegData)
-        return createCameraPhotoResult(image, fileURL)
-    }
-
-    fun processImageForGallery(image: UIImage, quality: Double = 0.9): GalleryPhotoResult {
-        val jpegData = convertToJPEG(image, quality)
-        val fileURL = saveImageToDisk(jpegData)
-        return createGalleryPhotoResult(image, fileURL)
-    }
-
-    private fun convertToJPEG(image: UIImage, quality: Double): NSData {
-        return UIImageJPEGRepresentation(image, quality)
-            ?: throw PhotoCaptureException("Failed to convert image to JPEG")
-    }
-
-    private fun saveImageToDisk(jpegData: NSData): NSURL {
-        val fileManager = NSFileManager.defaultManager
-        val tempDirectoryURL = fileManager.temporaryDirectory
-        val fileName = "${NSUUID().UUIDString()}.jpg"
-        val fileURL = tempDirectoryURL.URLByAppendingPathComponent(fileName)!!
-        val success = jpegData.writeToURL(fileURL, true)
-        if (!success) {
-            throw io.github.ismoy.imagepickerkmp.domain.exceptions.PhotoCaptureException("Failed to save image to disk")
+    /**
+     * Process an image with compression for camera capture
+     */
+    fun processImage(image: UIImage, compressionLevel: CompressionLevel): NSData? {
+        return try {
+            val quality = compressionLevel.toQualityValue()
+            val maxDimension = when (compressionLevel) {
+                CompressionLevel.HIGH -> 1280.0   // Más compresión = imagen más pequeña
+                CompressionLevel.MEDIUM -> 1920.0 // Compresión media
+                CompressionLevel.LOW -> 2560.0    // Menos compresión = imagen más grande
+            }
+            
+            // Debug logs
+            println("📸 iOS Camera ImageProcessor DEBUG:")
+            println("   CompressionLevel: $compressionLevel")
+            println("   Quality: $quality")
+            println("   MaxDimension: $maxDimension")
+            println("   Original size: ${image.size.useContents { "$width x $height" }}")
+            
+            val processedImage = resizeImageIfNeeded(image, maxDimension)
+            val result = UIImageJPEGRepresentation(processedImage, quality)
+            
+            println("   Final data size: ${result?.length ?: 0} bytes")
+            
+            result
+        } catch (e: Exception) {
+            println("❌ iOS Camera ImageProcessor error: ${e.message}")
+            null
         }
-        return fileURL
-    }
-
-    private fun createCameraPhotoResult(image: UIImage, fileURL: NSURL): PhotoResult {
-        val size = image.size
-        val uri = fileURL.absoluteString
-        if (uri.isNullOrEmpty()) {
-            throw PhotoCaptureException("Failed to get valid URI for saved image")
+    }    /**
+     * Process an image with compression for gallery selection
+     */
+    fun processImageForGallery(image: UIImage, compressionLevel: CompressionLevel): NSData? {
+        return try {
+            val quality = compressionLevel.toQualityValue()
+            val maxDimension = when (compressionLevel) {
+                CompressionLevel.HIGH -> 1280.0   // Más compresión = imagen más pequeña
+                CompressionLevel.MEDIUM -> 1920.0 // Compresión media
+                CompressionLevel.LOW -> 2560.0    // Menos compresión = imagen más grande
+            }
+            
+            // Debug logs
+            println("🔧 iOS ImageProcessor DEBUG:")
+            println("   CompressionLevel: $compressionLevel")
+            println("   Quality: $quality")
+            println("   MaxDimension: $maxDimension")
+            println("   Original size: ${image.size.useContents { "$width x $height" }}")
+            
+            val processedImage = resizeImageIfNeeded(image, maxDimension)
+            val result = UIImageJPEGRepresentation(processedImage, quality)
+            
+            println("   Final data size: ${result?.length ?: 0} bytes")
+            
+            result
+        } catch (e: Exception) {
+            println("❌ iOS ImageProcessor error: ${e.message}")
+            null
         }
-        return PhotoResult(
-            uri = uri,
-            width = size.useContents { width.toInt() },
-            height = size.useContents { height.toInt() }
-        )
     }
 
-    private fun createGalleryPhotoResult(image: UIImage, fileURL: NSURL): GalleryPhotoResult {
-        val size = image.size
-        val uri = fileURL.absoluteString
-        if (uri.isNullOrEmpty()) {
-            throw PhotoCaptureException("Failed to get valid URI for saved image")
+    /**
+     * Resize image if it exceeds the maximum size while maintaining aspect ratio
+     */
+    private fun resizeImageIfNeeded(image: UIImage, maxSize: Double): UIImage {
+        return image.size.useContents { 
+            if (width > maxSize || height > maxSize) {
+                val aspectRatio = width / height
+                val newSizeValue = if (width > height) {
+                    CGSizeMake(maxSize, maxSize / aspectRatio)
+                } else {
+                    CGSizeMake(maxSize * aspectRatio, maxSize)
+                }
+                return@useContents resizeImage(image, newSizeValue)
+            } else {
+                return@useContents image
+            }
         }
-        val fileSize = getFileSize(fileURL)
-        return GalleryPhotoResult(
-            uri = uri,
-            width = size.useContents { width.toInt() },
-            height = size.useContents { height.toInt() },
-            fileName = fileURL.lastPathComponent,
-            fileSize = fileSize
-        )
     }
 
+    /**
+     * Resize image to specific size
+     */
+    private fun resizeImage(image: UIImage, newSize: kotlinx.cinterop.CValue<platform.CoreGraphics.CGSize>): UIImage {
+        UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0)
+        newSize.useContents {
+            image.drawInRect(CGRectMake(0.0, 0.0, width, height))
+        }
+        val resizedImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return resizedImage ?: image
+    }
+
+    /**
+     * Save image data to temporary directory and return URL
+     */
+    fun saveImageToTempDirectory(imageData: NSData): NSURL? {
+        return try {
+            val tempDir = NSFileManager.defaultManager.temporaryDirectory
+            val fileName = "${NSUUID().UUIDString}.jpg"
+            val fileURL = tempDir?.URLByAppendingPathComponent(fileName)
+            
+            fileURL?.let { url ->
+                if (imageData.writeToURL(url, true)) {
+                    url
+                } else {
+                    null
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Get file size for a given URL
+     */
     private fun getFileSize(fileURL: NSURL): Long? {
         return try {
             val fileManager = NSFileManager.defaultManager
-            val attrs = fileManager.attributesOfItemAtPath(fileURL.path!!, null)
-            (attrs?.get("NSFileSize") as? NSNumber)?.longValue
+            val attributes = fileManager.attributesOfItemAtPath(fileURL.path!!, null)
+            (attributes?.get("NSFileSize") as? NSNumber)?.longValue
         } catch (e: Exception) {
-            println("Error getting file size: \\${e.message}")
             null
         }
     }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/CameraPresenter.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/CameraPresenter.kt
@@ -3,6 +3,7 @@ package io.github.ismoy.imagepickerkmp.presentation.presenters
 import io.github.ismoy.imagepickerkmp.data.delegates.CameraDelegate
 import io.github.ismoy.imagepickerkmp.domain.exceptions.PhotoCaptureException
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UIViewController
@@ -20,10 +21,16 @@ object CameraPresenter {
         viewController: UIViewController,
         onPhotoCaptured: (PhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: () -> Unit,
+        compressionLevel: CompressionLevel? = null
     ) {
         try {
-            val imagePickerController = createImagePickerController(onPhotoCaptured, onError, onDismiss)
+            val imagePickerController = createImagePickerController(
+                onPhotoCaptured,
+                onError,
+                onDismiss,
+                compressionLevel
+            )
             viewController.presentViewController(imagePickerController, animated = true, completion = null)
         } catch (e: Exception) {
             onError(PhotoCaptureException("Failed to present camera: ${e.message}"))
@@ -33,7 +40,8 @@ object CameraPresenter {
     private fun createImagePickerController(
         onPhotoCaptured: (PhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: () -> Unit,
+        compressionLevel: CompressionLevel? = null
     ): UIImagePickerController {
         return UIImagePickerController().apply {
             sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
@@ -52,7 +60,12 @@ object CameraPresenter {
                 onDismiss()
                 cleanup()
             }
-            cameraDelegate = CameraDelegate(wrappedOnPhotoCaptured, wrappedOnError, wrappedOnDismiss)
+            cameraDelegate = CameraDelegate(
+                wrappedOnPhotoCaptured,
+                wrappedOnError,
+                wrappedOnDismiss,
+                compressionLevel
+            )
             delegate = cameraDelegate
         }
     }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/GalleryPresenter.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/GalleryPresenter.kt
@@ -2,6 +2,7 @@ package io.github.ismoy.imagepickerkmp.presentation.presenters
 
 import io.github.ismoy.imagepickerkmp.data.delegates.GalleryDelegate
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerSourceType
 import platform.UIKit.UIViewController
@@ -18,10 +19,16 @@ object GalleryPresenter {
         viewController: UIViewController,
         onPhotoSelected: (GalleryPhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: () -> Unit,
+        compressionLevel: CompressionLevel? = null
     ) {
         try {
-            val imagePickerController = createImagePickerController(onPhotoSelected, onError, onDismiss)
+            val imagePickerController = createImagePickerController(
+                onPhotoSelected,
+                onError,
+                onDismiss,
+                compressionLevel
+            )
             viewController.presentViewController(imagePickerController, animated = true, completion = null)
         } catch (e: Exception) {
             onError(Exception("Failed to present gallery: ${e.message}"))
@@ -31,7 +38,8 @@ object GalleryPresenter {
     private fun createImagePickerController(
         onPhotoSelected: (GalleryPhotoResult) -> Unit,
         onError: (Exception) -> Unit,
-        onDismiss: () -> Unit
+        onDismiss: () -> Unit,
+        compressionLevel: CompressionLevel? = null
     ): UIImagePickerController {
         return UIImagePickerController().apply {
             sourceType = UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypePhotoLibrary
@@ -50,8 +58,7 @@ object GalleryPresenter {
                 onDismiss()
                 cleanup()
             }
-            galleryDelegate =
-                GalleryDelegate(wrappedOnPhotoSelected, wrappedOnError, wrappedOnDismiss)
+            galleryDelegate = GalleryDelegate(wrappedOnPhotoSelected, compressionLevel)
             delegate = galleryDelegate
         }
     }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/PHPickerPresenter.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/PHPickerPresenter.kt
@@ -3,6 +3,7 @@ package io.github.ismoy.imagepickerkmp.presentation.presenters
 import io.github.ismoy.imagepickerkmp.data.delegates.PHPickerDelegate
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.SELECTION_LIMIT
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import platform.PhotosUI.PHPickerConfiguration
 import platform.PhotosUI.PHPickerFilter
 import platform.PhotosUI.PHPickerViewController
@@ -21,11 +22,18 @@ object PHPickerPresenter {
         onPhotoSelected: (GalleryPhotoResult) -> Unit,
         onError: (Exception) -> Unit,
         onDismiss: () -> Unit,
-        selectionLimit: Long
+        selectionLimit: Long,
+        compressionLevel: CompressionLevel? = null
     ) {
         require(selectionLimit <= SELECTION_LIMIT) {"Selection limit cannot exceed $SELECTION_LIMIT"}
         try {
-            val pickerViewController = createPHPickerController(onPhotoSelected, onError, onDismiss, selectionLimit)
+            val pickerViewController = createPHPickerController(
+                onPhotoSelected,
+                onError,
+                onDismiss,
+                selectionLimit,
+                compressionLevel
+            )
             viewController.presentViewController(pickerViewController,
                 animated = true, completion = null)
         } catch (e: Exception) {
@@ -37,7 +45,8 @@ object PHPickerPresenter {
         onPhotoSelected: (GalleryPhotoResult) -> Unit,
         onError: (Exception) -> Unit,
         onDismiss: () -> Unit,
-        selectionLimit: Long
+        selectionLimit: Long,
+        compressionLevel: CompressionLevel? = null
     ): PHPickerViewController {
         val configuration = PHPickerConfiguration()
         configuration.selectionLimit = selectionLimit
@@ -56,7 +65,12 @@ object PHPickerPresenter {
             onDismiss()
             cleanup()
         }
-        pickerDelegate = PHPickerDelegate(wrappedOnPhotoSelected, wrappedOnError, wrappedOnDismiss)
+        pickerDelegate = PHPickerDelegate(
+            wrappedOnPhotoSelected,
+            wrappedOnError,
+            wrappedOnDismiss,
+            compressionLevel
+        )
         return PHPickerViewController(configuration).apply {
             delegate = pickerDelegate
         }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/GalleryPickerLauncher.ios.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/GalleryPickerLauncher.ios.kt
@@ -19,6 +19,8 @@ actual fun GalleryPickerLauncher(
     cameraCaptureConfig: CameraCaptureConfig?
 ) {
     LaunchedEffect(Unit) {
+        val compressionLevel = cameraCaptureConfig?.compressionLevel
+        
         if (allowMultiple) {
             val selectedImages = mutableListOf<GalleryPhotoResult>()
             GalleryPickerOrchestrator.launchGallery(
@@ -29,7 +31,8 @@ actual fun GalleryPickerLauncher(
                 onError = onError,
                 onDismiss = onDismiss,
                 allowMultiple = true,
-                selectionLimit = selectionLimit
+                selectionLimit = selectionLimit,
+                compressionLevel = compressionLevel
             )
         } else {
             GalleryPickerOrchestrator.launchGallery(
@@ -37,7 +40,8 @@ actual fun GalleryPickerLauncher(
                 onError = onError,
                 onDismiss = onDismiss,
                 allowMultiple = false,
-                selectionLimit = 1
+                selectionLimit = 1,
+                compressionLevel = compressionLevel
             )
         }
     }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/ImagePickerLauncher.ios.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/ImagePickerLauncher.ios.kt
@@ -14,6 +14,7 @@ import io.github.ismoy.imagepickerkmp.domain.config.CameraPermissionDialogConfig
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerConfig
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import platform.Foundation.setValue
 import platform.UIKit.UIAlertAction
 import platform.UIKit.UIAlertController
@@ -114,7 +115,8 @@ private fun handleImagePickerState(
             onPhotoCaptured = config.onPhotoCaptured,
             onError = config.onError,
             onDismiss = config.onDismiss,
-            onFinish = onCameraFinished
+            onFinish = onCameraFinished,
+            compressionLevel = config.cameraCaptureConfig?.compressionLevel
         )
     }
 
@@ -122,17 +124,23 @@ private fun handleImagePickerState(
         launchGalleryInternal(
             onPhotoSelected = { result ->
                 config.onPhotosSelected?.invoke(listOf(result))
+                println("📱 iOS ImagePickerLauncher DEBUG:")
+                println("   Gallery result fileSize: ${result.fileSize}KB")
                 config.onPhotoCaptured(
                     PhotoResult(
                         uri = result.uri,
                         width = result.width,
-                        height = result.height
+                        height = result.height,
+                        fileName = result.fileName,
+                        fileSize = result.fileSize
                     )
                 )
+                println("   PhotoResult fileSize: ${result.fileSize}KB")
             },
             onError = config.onError,
             onDismiss = config.onDismiss,
-            onFinish = onGalleryFinished
+            onFinish = onGalleryFinished,
+            compressionLevel = config.cameraCaptureConfig?.compressionLevel
         )
     }
 }
@@ -196,7 +204,8 @@ private fun launchCameraInternal(
     onPhotoCaptured: (PhotoResult) -> Unit,
     onError: (Exception) -> Unit,
     onDismiss: () -> Unit,
-    onFinish: () -> Unit
+    onFinish: () -> Unit,
+    compressionLevel: CompressionLevel? = null
 ) {
     LaunchedEffect(Unit) {
         PhotoCaptureOrchestrator.launchCamera(
@@ -211,7 +220,8 @@ private fun launchCameraInternal(
             onDismiss = {
                 onDismiss()
                 onFinish()
-            }
+            },
+            compressionLevel = compressionLevel
         )
     }
 }
@@ -221,7 +231,8 @@ private fun launchGalleryInternal(
     onPhotoSelected: (GalleryPhotoResult) -> Unit,
     onError: (Exception) -> Unit,
     onDismiss: () -> Unit,
-    onFinish: () -> Unit
+    onFinish: () -> Unit,
+    compressionLevel: CompressionLevel? = null
 ) {
     LaunchedEffect(Unit) {
         GalleryPickerOrchestrator.launchGallery(
@@ -233,7 +244,8 @@ private fun launchGalleryInternal(
                 onError(it)
                 onFinish()
             },
-            onDismiss = onDismiss
+            onDismiss = onDismiss,
+            compressionLevel = compressionLevel
         )
     }
 }


### PR DESCRIPTION
- Update PhotoResult and GalleryPhotoResult models to return fileSize in KB
- Add bytesToKB utility function with minimum 1KB guarantee
- Improve error handling with structured logging across iOS and Android
- Add debug logs for better troubleshooting experience
- Replace silent exception catching with proper error reporting
- Enhance code maintainability by extracting common conversion logic

Affected components:
- iOS: GalleryDelegate, CameraDelegate
- Android: GalleryPickerLauncher, CameraCapturePreview, ImageProcessor
- Models: PhotoResult, GalleryPhotoResult documentation updated

Example: 777,853 bytes now displays as 759KB for better UX