### PR TITLE
fix: Android API 29 camera blank screen and improve gallery picker UX

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,4 @@ plugins {
     id("jacoco")
 }
 
-version = "1.0.28"
+version = "1.0.29"

--- a/library/src/androidMain/AndroidManifest.xml
+++ b/library/src/androidMain/AndroidManifest.xml
@@ -2,11 +2,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-feature android:name="android.hardware.camera" android:required="true" />
+    
+    <uses-feature 
+        android:name="android.hardware.camera" 
+        android:required="false" />
+    <uses-feature 
+        android:name="android.hardware.camera.autofocus" 
+        android:required="false" />
+    <uses-feature 
+        android:name="android.hardware.camera.any" 
+        android:required="false" />
     
 
     <application>
-        <!-- FileProvider for sharing images -->
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/AndroidGalleryConfig.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/AndroidGalleryConfig.kt
@@ -2,40 +2,11 @@ package io.github.ismoy.imagepickerkmp.domain.config
 
 import io.github.ismoy.imagepickerkmp.domain.models.MimeType
 
-/**
- * Configuration options for gallery picker behavior on Android.
- * Allows choosing between different picker strategies to handle different device behaviors.
- */
 data class AndroidGalleryConfig(
-    /**
-     * Force the use of gallery-only picker instead of generic file picker.
-     * 
-     * When true: Uses Intent.ACTION_PICK with MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-     *            This ensures the gallery app opens instead of file manager.
-     * 
-     * When false: Uses ActivityResultContracts.GetContent() (default behavior)
-     *             This may open file manager on some devices.
-     * 
-     * Default: true (to ensure gallery opens), but automatically set to false if PDFs are requested
-     */
     val forceGalleryOnly: Boolean = true,
-    
-    /**
-     * Include local images only (not cloud storage).
-     * This adds EXTRA_LOCAL_ONLY to the intent.
-     * 
-     * Default: true
-     */
-    val localOnly: Boolean = true
+    val localOnly: Boolean = false 
 ) {
     companion object {
-        /**
-         * Creates an AndroidGalleryConfig that automatically determines the best picker strategy
-         * based on the requested MIME types.
-         * 
-         * @param mimeTypes List of MIME types to be selected
-         * @return AndroidGalleryConfig with appropriate settings
-         */
         fun forMimeTypes(mimeTypes: List<MimeType>): AndroidGalleryConfig {
             val hasPdfTypes = mimeTypes.any { 
                 it == MimeType.APPLICATION_PDF || it.value.contains("pdf", ignoreCase = true)
@@ -44,18 +15,14 @@ data class AndroidGalleryConfig(
                 !it.value.startsWith("image/", ignoreCase = true) && it != MimeType.IMAGE_ALL
             }
             
-            // Use generic picker for PDFs or non-image types
             val shouldUseGenericPicker = hasPdfTypes || hasNonImageTypes
             
             return AndroidGalleryConfig(
                 forceGalleryOnly = !shouldUseGenericPicker,
-                localOnly = true
+                localOnly = false
             )
         }
         
-        /**
-         * Creates an AndroidGalleryConfig for string-based MIME types
-         */
         fun forMimeTypeStrings(mimeTypes: List<String>): AndroidGalleryConfig {
             val hasPdfTypes = mimeTypes.any { 
                 it.contains("pdf", ignoreCase = true) || it.contains("application/pdf", ignoreCase = true)
@@ -68,7 +35,7 @@ data class AndroidGalleryConfig(
             
             return AndroidGalleryConfig(
                 forceGalleryOnly = !shouldUseGenericPicker,
-                localOnly = true
+                localOnly = false
             )
         }
     }

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/HighPerformanceConfig.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/HighPerformanceConfig.kt
@@ -2,12 +2,7 @@ package io.github.ismoy.imagepickerkmp.domain.config
 
 import android.os.Build
 
-/**
- * High-performance configuration optimizations for flagship Android devices.
- * 
- * This object provides optimized settings for devices like Galaxy S24 Ultra
- * and other high-end Android devices to improve camera capture performance.
- */
+
 object HighPerformanceConfig {
     
 
@@ -20,15 +15,15 @@ object HighPerformanceConfig {
                  Build.MODEL?.contains("Pixel", ignoreCase = true) == true)
     }
 
-    /**
-     * Gets the optimal JPEG quality for high-end devices.
-     * Balances quality vs performance for flagship devices.
-     */
+    fun requiresCompatibilityMode(): Boolean {
+        return Build.VERSION.SDK_INT == Build.VERSION_CODES.Q 
+    }
+
     fun getOptimalJpegQuality(): Int {
-        return if (isHighEndDevice()) {
-            95
-        } else {
-            85
+        return when {
+            Build.VERSION.SDK_INT == Build.VERSION_CODES.Q -> 90 
+            isHighEndDevice() -> 95
+            else -> 85
         }
     }
 }

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCaptureStateHolder.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCaptureStateHolder.kt
@@ -1,5 +1,7 @@
 package io.github.ismoy.imagepickerkmp.presentation.ui.components
 
+import android.os.Build
+import android.util.Log
 import androidx.camera.view.PreviewView
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,12 +17,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-/**
- * Holds and manages the state for camera capture operations, including flash mode, loading state,
- * and camera switching.
- *
- * This class coordinates camera actions and state updates for the UI.
- */
 class CameraCaptureStateHolder(
     private val cameraManager: CameraXManager,
     private val previewView: PreviewView,
@@ -44,7 +40,7 @@ class CameraCaptureStateHolder(
         cameraJob?.cancel()
         cameraJob = coroutineScope.launch {
             try {
-                isLoading = true
+                isLoading = true                
                 cameraManager.setFlashMode(flashMode)
                 cameraManager.startCamera(previewView, preference)
                 isLoading = false

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryOnlyPickerLaunchers.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryOnlyPickerLaunchers.kt
@@ -21,15 +21,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 
-/**
- * Custom contract for picking images specifically from gallery (not file manager).
- * This contract uses ACTION_PICK with MediaStore to ensure gallery is opened.
- */
+
 class PickImageFromGallery : ActivityResultContract<String, Uri?>() {
     override fun createIntent(context: Context, input: String): Intent {
-        return Intent(Intent.ACTION_PICK).apply {
-            setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, input)
-            putExtra(Intent.EXTRA_LOCAL_ONLY, true)
+        return Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = input
+            addCategory(Intent.CATEGORY_OPENABLE)
         }
     }
 
@@ -38,15 +35,12 @@ class PickImageFromGallery : ActivityResultContract<String, Uri?>() {
     }
 }
 
-/**
- * Custom contract for picking multiple images specifically from gallery.
- */
 class PickMultipleImagesFromGallery : ActivityResultContract<String, List<Uri>>() {
     override fun createIntent(context: Context, input: String): Intent {
-        return Intent(Intent.ACTION_PICK).apply {
-            setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, input)
+        return Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = input
+            addCategory(Intent.CATEGORY_OPENABLE)
             putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-            putExtra(Intent.EXTRA_LOCAL_ONLY, true)
         }
     }
 
@@ -54,7 +48,6 @@ class PickMultipleImagesFromGallery : ActivityResultContract<String, List<Uri>>(
         val uris = mutableListOf<Uri>()
         
         intent?.let {
-            // Handle multiple selection
             it.clipData?.let { clipData ->
                 for (i in 0 until clipData.itemCount) {
                     clipData.getItemAt(i).uri?.let { uri ->
@@ -62,7 +55,6 @@ class PickMultipleImagesFromGallery : ActivityResultContract<String, List<Uri>>(
                     }
                 }
             }
-            // Handle single selection
             it.data?.let { uri ->
                 if (uris.isEmpty()) {
                     uris.add(uri)
@@ -74,9 +66,6 @@ class PickMultipleImagesFromGallery : ActivityResultContract<String, List<Uri>>(
     }
 }
 
-/**
- * Launcher for single image selection specifically from gallery.
- */
 @Composable
 internal fun rememberGalleryOnlyPickerLauncher(
     context: Context,
@@ -106,9 +95,6 @@ internal fun rememberGalleryOnlyPickerLauncher(
     }
 }
 
-/**
- * Launcher for multiple image selection specifically from gallery.
- */
 @Composable
 internal fun rememberGalleryOnlyMultiplePickerLauncher(
     context: Context,


### PR DESCRIPTION
- Add 100ms initialization delay for API 29 camera preview
- Configure COMPATIBLE mode and 16:9 aspect ratio for API 29
- Change gallery picker to ACTION_GET_CONTENT for multi-source access
- Set localOnly=false to enable Drive/Photos access from gallery
- Update camera features to optional in AndroidManifest