### PR TITLE
feat: Handle picker dismissal on iOS and improve Android result handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,4 @@ plugins {
     id("jacoco")
 }
 
-version = "1.0.29"
+version = "1.0.30"

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryOnlyPickerLaunchers.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryOnlyPickerLaunchers.kt
@@ -31,6 +31,9 @@ class PickImageFromGallery : ActivityResultContract<String, Uri?>() {
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
+        if (resultCode != android.app.Activity.RESULT_OK) {
+            return null
+        }
         return intent?.data
     }
 }
@@ -46,6 +49,10 @@ class PickMultipleImagesFromGallery : ActivityResultContract<String, List<Uri>>(
 
     override fun parseResult(resultCode: Int, intent: Intent?): List<Uri> {
         val uris = mutableListOf<Uri>()
+        
+        if (resultCode != android.app.Activity.RESULT_OK) {
+            return uris 
+        }
         
         intent?.let {
             it.clipData?.let { clipData ->

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryPickerLaunchers.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/gallery/GalleryPickerLaunchers.kt
@@ -18,9 +18,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 
-/**
- * Launcher for single file selection from gallery.
- */
+
 @Composable
 internal fun rememberSinglePickerLauncher(
     context: Context,
@@ -50,10 +48,6 @@ internal fun rememberSinglePickerLauncher(
     }
 }
 
-/**
- * Launcher for multiple file selection from gallery.
- * Optimized with parallel processing (max 3 concurrent) for better performance.
- */
 @Composable
 internal fun rememberMultiplePickerLauncher(
     context: Context,

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/delegates/PHPickerDelegate.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/data/delegates/PHPickerDelegate.kt
@@ -2,6 +2,7 @@ package io.github.ismoy.imagepickerkmp.data.delegates
 
 import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.presentation.presenters.DismissalAwarePHPickerViewController
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.PhotosUI.PHPickerResult
 import platform.PhotosUI.PHPickerViewController
@@ -20,12 +21,18 @@ class PHPickerDelegate(
     private val compressionLevel: CompressionLevel? = null,
     private val includeExif: Boolean = false
 ) : NSObject(), PHPickerViewControllerDelegateProtocol {
+    
+    private var dismissHandled = false
 
     @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
     override fun picker(
         picker: PHPickerViewController,
         didFinishPicking: List<*>
     ) {
+        dismissHandled = true
+        
+        DismissalAwarePHPickerViewController.markDismissalHandled(picker)
+        
         if (didFinishPicking.isEmpty()) {
             onDismiss()
             dismissPicker(picker)
@@ -66,6 +73,13 @@ class PHPickerDelegate(
     private fun dismissPicker(picker: PHPickerViewController) {
         dispatch_async(dispatch_get_main_queue()) {
             picker.dismissViewControllerAnimated(true, completion = null)
+        }
+    }
+
+    fun onPickerDismissed() {
+        if (!dismissHandled) {
+            dismissHandled = true
+            onDismiss()
         }
     }
 }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/CreatePHPickerController.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/CreatePHPickerController.kt
@@ -57,7 +57,11 @@ private var strongPickerDelegate: PHPickerDelegate? = null
         includeExif
     )
 
-    return PHPickerViewController(configuration).apply {
-        delegate = strongPickerDelegate
+    val pickerDelegate = strongPickerDelegate ?: return PHPickerViewController(configuration).apply {
+        delegate = null
+    }
+
+    return DismissalAwarePHPickerViewController.createPickerViewController(configuration, pickerDelegate).apply {
+        delegate = pickerDelegate
     }
 }

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/DismissalAwarePHPickerViewController.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/presenters/DismissalAwarePHPickerViewController.kt
@@ -1,0 +1,72 @@
+package io.github.ismoy.imagepickerkmp.presentation.presenters
+
+import io.github.ismoy.imagepickerkmp.data.delegates.PHPickerDelegate
+import io.ktor.util.date.getTimeMillis
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerViewController
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+import kotlin.time.ExperimentalTime
+
+
+@OptIn(ExperimentalForeignApi::class)
+object DismissalAwarePHPickerViewController {
+    private val dismissalMonitors = mutableMapOf<Int, DismissalMonitor>()
+    
+    fun createPickerViewController(
+        configuration: PHPickerConfiguration,
+        pickerDelegate: PHPickerDelegate
+    ): PHPickerViewController {
+        val picker = PHPickerViewController(configuration)
+        
+        val monitor = DismissalMonitor(picker, pickerDelegate)
+        dismissalMonitors[picker.hashCode()] = monitor
+        monitor.startMonitoring()
+        
+        return picker
+    }
+    
+    fun markDismissalHandled(picker: PHPickerViewController) {
+        val hashCode = picker.hashCode()
+        dismissalMonitors[hashCode]?.stopMonitoring()
+        dismissalMonitors.remove(hashCode)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private class DismissalMonitor(
+    private val picker: PHPickerViewController,
+    private val pickerDelegate: PHPickerDelegate
+) {
+    private var isMonitoring = false
+    private var monitoringStartTime = 0L
+    
+    @OptIn(ExperimentalTime::class)
+    fun startMonitoring() {
+        if (isMonitoring) return
+        isMonitoring = true
+        monitoringStartTime = getTimeMillis()
+        scheduleCheck()
+    }
+    
+    fun stopMonitoring() {
+        isMonitoring = false
+    }
+    
+    private fun scheduleCheck() {
+        if (!isMonitoring) return
+        
+        dispatch_async(dispatch_get_main_queue()) {
+            if (isMonitoring && picker.viewIfLoaded?.window == null) {
+                stopMonitoring()
+                pickerDelegate.onPickerDismissed()
+                DismissalAwarePHPickerViewController.markDismissalHandled(picker)
+            } else if (isMonitoring) {
+                dispatch_async(dispatch_get_main_queue()) {
+                    scheduleCheck()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Implemented a dismissal detection mechanism for `PHPickerViewController` on iOS to correctly handle cases where the user dismisses the picker without making a selection.
- Introduced `DismissalAwarePHPickerViewController` to monitor and manage picker dismissal states.
- Ensured that on Android, if the user cancels the picker (`RESULT_CANCELED`), the launcher returns a null or empty list instead of processing further.
- Removed redundant KDoc comments from Android launcher composables.
- Incremented the project version to `1.0.30`.