### PR TITLE
fix: ensure 1:1 aspect ratio for initial crop handles in circular mode

### DIFF
--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CropImageCanvas.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CropImageCanvas.kt
@@ -177,8 +177,19 @@ import kotlin.math.min
                     val margin = 40f
                     val availableWidth = size.width - margin * 2
                     val availableHeight = size.height - margin * 2
-                    val rectWidth = availableWidth * 0.8f
-                    val rectHeight = availableHeight * 0.6f
+                    val rectWidth: Float
+                    val rectHeight: Float
+                    when {
+                        isCircularCrop -> {
+                            val side = min(availableWidth, availableHeight) * 0.7f
+                            rectWidth = side
+                            rectHeight = side
+                        }
+                        else -> {
+                            rectWidth = availableWidth * 0.8f
+                            rectHeight = availableHeight * 0.6f
+                        }
+                    }
                     val centerX = size.width / 2
                     val centerY = size.height / 2
                     localCropRect = Rect(


### PR DESCRIPTION
- close: #101 

Updated the initialization logic in CropImageCanvas to enforce a square Rect when isCircularCrop is enabled.

<img width="316" height="636" alt="image" src="https://github.com/user-attachments/assets/72dc210c-6600-4d7d-9b30-7d87d8e71c7a" />