### PR TITLE
Fix `createFallbackResult` to persist image to cache file instead of returning content:// URI

### DIFF
--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryFileUtils.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryFileUtils.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.GALLERY_FILE_UTILS_TAG
+import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.PREFIX_GALLERY
 import io.github.ismoy.imagepickerkmp.domain.utils.DefaultLogger
 
 internal object GalleryFileUtils {
@@ -26,5 +27,14 @@ internal object GalleryFileUtils {
             }
         }
         return result
+    }
+
+    fun String?.getNameAndExtension(prefix: String = PREFIX_GALLERY): Pair<String?, String?> {
+        val fileName = this
+        val hasExtension = fileName?.contains('.') == true && fileName.lastIndexOf('.') > 0
+        var name = if (hasExtension) fileName.substringBeforeLast('.') else fileName
+        name = name?.let { prefix.plus(it).plus("_") }
+        val extension = if (hasExtension) '.'.plus(fileName.substringAfterLast('.')) else null
+        return name to extension
     }
 }

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryImageCompressor.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryImageCompressor.kt
@@ -2,10 +2,13 @@ package io.github.ismoy.imagepickerkmp.data.gallery
 
 import android.content.Context
 import android.graphics.Bitmap
+import io.github.ismoy.imagepickerkmp.data.gallery.GalleryFileUtils.getNameAndExtension
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.GALLERY_PROCESSOR_TAG
+import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.IMAGE_TEMP
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.MINVALUE_COMPRESSOR
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.NUMBER_THREE
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.PREFIX_COMPRESSED_GALLERY
+import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.PREFIX_GALLERY
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.SUFFIX_COMPRESSED_GALLERY
 import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.utils.DefaultLogger
@@ -23,12 +26,15 @@ internal object GalleryImageCompressor {
         return out.toByteArray()
     }
 
-    fun createTempImageFile(context: Context, imageBytes: ByteArray): File? {
+    fun createTempImageFile(context: Context, imageBytes: ByteArray, fileName: String? = null): File? {
+        val (name, extension) = fileName.getNameAndExtension()
+        val storageDir = context.cacheDir.resolve(IMAGE_TEMP).also { it.mkdirs() }
+
         val tempFile = try {
             File.createTempFile(
-                "$PREFIX_COMPRESSED_GALLERY${System.currentTimeMillis()}",
-                SUFFIX_COMPRESSED_GALLERY,
-                context.cacheDir
+                name ?: "$PREFIX_COMPRESSED_GALLERY${System.currentTimeMillis()}",
+                extension ?: SUFFIX_COMPRESSED_GALLERY,
+                storageDir
             )
         } catch (e: Exception) {
             DefaultLogger.logDebug("$GALLERY_PROCESSOR_TAG: Error creating temp file: ${e.javaClass.simpleName}")

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryImageProcessor.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/data/gallery/GalleryImageProcessor.kt
@@ -43,7 +43,7 @@ internal object GalleryImageProcessor {
                 ?: return@withContext null
 
             if (compressionLevel == null && !includeExif) {
-                return@withContext createFallbackResult(uri, originalBytes, fileName, mimeType, null)
+                return@withContext createFallbackResult(context, uri, originalBytes, fileName, mimeType, null)
             }
 
             val exifData: ExifData? = if (includeExif && mimeType?.startsWith(IMAGE_PREFIX_TEXT) == true) {
@@ -56,10 +56,10 @@ internal object GalleryImageProcessor {
                 if (bitmap != null) {
                     createResultFromBitmap(context, bitmap, fileName, mimeType, exifData, compressionLevel)
                 } else {
-                    createFallbackResult(uri, originalBytes, fileName, mimeType, exifData)
+                    createFallbackResult(context, uri, originalBytes, fileName, mimeType, exifData)
                 }
             } else {
-                createFallbackResult(uri, originalBytes, fileName, mimeType, exifData)
+                createFallbackResult(context, uri, originalBytes, fileName, mimeType, exifData)
             }
         } catch (e: Exception) {
             DefaultLogger.logDebug("$IMAGEPROCESSOR_TAG: ${e.message}")
@@ -135,6 +135,7 @@ internal object GalleryImageProcessor {
     }
 
     private fun createFallbackResult(
+        context: Context,
         uri: Uri,
         originalBytes: ByteArray,
         fileName: String?,
@@ -143,11 +144,15 @@ internal object GalleryImageProcessor {
     ): GalleryPhotoResult {
         val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(originalBytes, NUMBER_ZERO, originalBytes.size, options)
+
+        val tempFile = GalleryImageCompressor.createTempImageFile(context, originalBytes, fileName)
+        val tempUri = tempFile?.let { Uri.fromFile(it).toString() }
+
         return GalleryPhotoResult(
-            uri = uri.toString(),
+            uri = tempUri ?: uri.toString(),
             width = options.outWidth,
             height = options.outHeight,
-            fileName = fileName,
+            fileName = tempFile?.name ?: fileName,
             fileSize = originalBytes.size.toLong(),
             mimeType = mimeType,
             exif = exifData

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerUiConstants.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerUiConstants.kt
@@ -53,6 +53,7 @@ internal object ImagePickerUiConstants {
     const val GALLERY_FILE_UTILS_TAG = "GalleryFileUtils: Error querying file name:"
     const val NUMBER_THREE = 3
     const val MINVALUE_COMPRESSOR = 8192
+    const val PREFIX_GALLERY = "gallery_"
     const val PREFIX_COMPRESSED_GALLERY = "compressed_gallery_"
     const val SUFFIX_COMPRESSED_GALLERY = ".jpg"
     const val NUMBER_ZERO = 0


### PR DESCRIPTION
## Description

Update `createFallbackResult` to ensure the image is persisted to the cache with a `file://` URI, rather than returning a `content:// `URI.

When both `compression: null` and `includeExif: false` are provided, the code previously fell back to `createFallbackResult`, which returned the original `content://` URI directly. If the user stored this URI in a database, they would later be unable to read the file because `content://` URIs from the media picker are temporary and not persistent across app sessions.

**Old behavior:**
- Returns `content://media/picker_get_content/...` URI
- File cannot be accessed after being stored in local database
- Leads to "File not found" errors when retrieving saved paths

**New behavior:**
- Creates a permanent cached file in app's internal storage
- Returns `file://` URI that persists and remains readable
- Falls back to original URI only if temp file creation fails

**Code change:**
```kotlin
// Before
private fun createFallbackResult(
    uri: Uri,
    originalBytes: ByteArray,
    fileName: String?,
    mimeType: String?,
    exifData: ExifData?
): GalleryPhotoResult

// After
private fun createFallbackResult(
    context: Context,
    uri: Uri,
    originalBytes: ByteArray,
    fileName: String?,
    mimeType: String?,
    exifData: ExifData?
): GalleryPhotoResult
```

Fixes issue where stored image paths become invalid when using default settings (no compression, no EXIF).

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup (no functional changes)
- [ ] Performance improvement
- [ ] Test additions or improvements
- [ ] Security fix

---

## Testing

- [ ] Unit tests (commonTest)
- [ ] Android instrumented tests
- [ ] iOS tests
- [x] Tested manually on Android
- [ ] Tested manually on iOS
- [ ] Tested on Desktop (JVM)
- [ ] Tested on Web (JS / Wasm)

**Test configuration:**
- Emulator: Pixel_4a_SDK37.0
- OS version: Android 17 (SDK37.0)
- Library version tested against: 2.0.39

**Test scenario:**
1. Select image from gallery with `compression = null` and `includeExif = false`
2. Observe log: `GalleryImageProcessor: No compression and no EXIF requested - returning fallback result`
3. New log shows `file://` URI instead of `content://`
4. Save URI to database, kill app, restart and retrieve - file is accessible

---

## Checklist

- [x] My code follows the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
- [ ] I have run `./gradlew detekt` and there are no new issues
- [ ] I have added/updated tests to cover my changes
- [ ] All existing tests pass (`./gradlew test`)
- [ ] I have updated the relevant documentation (KDoc, `docs/`, README if needed)
- [ ] I have added an entry to `docs/CHANGELOG.md` under `[Unreleased]`
- [ ] My branch is based on `develop` (not `main`)
- [x] I have not introduced any breaking API changes (or they are documented and justified)

---

## Additional Context

### Why this matters
- `content://` URIs from `ActivityResultContracts.PickVisualMedia` are transient
- Apps often store selected image paths in local databases for later display
- Without this fix, users see broken images after app restart

### Migration note for existing users
- No migration needed - new calls will receive `file://` URIs
- Previously stored `content://` URIs will remain broken and need re-selection by users