### PR TITLE
feat: add absolute path support and kotlinx-io extensions for PhotoResult

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -361,6 +361,18 @@ if (showCamera) {
                 val imageBitmap = result.loadImageBitmap() // Para operaciones gráficas
                 val imageBase64 = result.loadBase64()      // Para llamadas API
                 
+                // Operaciones con el sistema de archivos (kotlinx-io)
+                val absolutePath = result.absolutePath     // String - ruta absoluta del archivo
+                val path = result.asPath()                 // Objeto Path para operaciones de archivo
+                val exists = result.exists()               // Comprobar si el archivo existe
+                val rawSource = result.asRawSource()       // RawSource para lectura de bajo nivel
+                val source = result.asSource()             // Buffered Source para lectura eficiente
+
+                // Copiar la foto a otra ubicación
+                val sink = SystemFileSystem
+                    .sink(Path("copy.jpg"))
+                result.transferToSink(sink)                // Transferir contenido a RawSink
+
                 // Guardar el painter para mostrar después
                 capturedImage = imagePainter
                 showCamera = false

--- a/README.md
+++ b/README.md
@@ -465,6 +465,18 @@ ImagePickerLauncher(
             val imagePainter = result.loadPainter()    // Painter for Compose UI
             val imageBitmap = result.loadImageBitmap() // ImageBitmap for graphics
             val imageBase64 = result.loadBase64()      // Base64 string for APIs
+
+            // File system operations (kotlinx-io)
+            val absolutePath = result.absolutePath     // String - absolute file path
+            val path = result.asPath()                 // Path object for file operations
+            val exists = result.exists()               // Check if file exists
+            val rawSource = result.asRawSource()       // RawSource for low-level reading
+            val source = result.asSource()             // Buffered Source for efficient reading
+
+            // Copy photo to another location
+            val sink = SystemFileSystem
+                .sink(Path("copy.jpg"))
+            result.transferToSink(sink)                // Transfer content to RawSink
         }
     )
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlin = "2.3.20"
 compose = "1.10.3"
 androidx-activityCompose = "1.13.0"
 kotlinxCoroutinesCore = "1.10.2"
+kotlinxIoCore = "0.9.0"
 material3 = "1.9.0"
 materialIcons = "1.7.3"
 ui = "1.10.5"
@@ -38,6 +39,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIoCore" }
 material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "materialIcons" }
 material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIcons" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ accompanistPermissions = "0.37.3"
 agp = "8.13.2"
 cameraCore = "1.6.0"
 cameraView = "1.6.0"
+coilCompose = "3.2.0"
 core = "3.5.4"
 exifinterface = "1.4.2"
 lifecycleRuntimeCompose = "2.10.0"
@@ -10,7 +11,8 @@ kotlin = "2.3.20"
 compose = "1.10.3"
 androidx-activityCompose = "1.13.0"
 kotlinxCoroutinesCore = "1.10.2"
-materialIconsExtendedVersion = "1.7.8"
+material3 = "1.9.0"
+materialIcons = "1.7.3"
 ui = "1.10.5"
 kover = "0.9.7"
 
@@ -22,22 +24,26 @@ androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", versi
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "cameraView" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "exifinterface" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
-androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtendedVersion" }
 androidx-ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "ui" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
 components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose" }
 compose-animation = { module = "org.jetbrains.compose.animation:animation", version.ref = "compose" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "compose" }
-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "compose" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "material3" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinxCoroutinesCore" }
+material-icons-core = { module = "org.jetbrains.compose.material:material-icons-core", version.ref = "materialIcons" }
+material-icons-extended = { module = "org.jetbrains.compose.material:material-icons-extended", version.ref = "materialIcons" }
+
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version = "2.3.20" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "compose" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -270,6 +270,7 @@ kotlin {
             implementation(libs.compose.material)
             implementation(libs.compose.material3)
             implementation(libs.kotlinx.coroutines.core)
+            api(libs.kotlinx.io.core)
             implementation(libs.coil.compose)
             implementation(libs.material.icons.core)
             implementation(libs.material.icons.extended)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -262,37 +262,31 @@ kotlin {
     }
     withSourcesJar(true)
     sourceSets {
-        val commonMain by getting {
-            dependencies {
-                api(libs.compose.runtime)
-                implementation(libs.compose.ui)
-                implementation(libs.compose.animation)
-                implementation(libs.compose.foundation)
-                implementation(libs.compose.material)
-                implementation(compose.material3)
-                implementation(libs.kotlinx.coroutines.core)
-                implementation("io.coil-kt.coil3:coil-compose:3.2.0")
-                implementation("org.jetbrains.compose.material:material-icons-core:1.7.3")
-                implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
-                implementation(libs.components.resources)
-            }
+        commonMain.dependencies {
+            api(libs.compose.runtime)
+            implementation(libs.compose.ui)
+            implementation(libs.compose.animation)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material)
+            implementation(libs.compose.material3)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.coil.compose)
+            implementation(libs.material.icons.core)
+            implementation(libs.material.icons.extended)
+            implementation(libs.components.resources)
         }
-        val androidMain by getting {
-            dependencies {
-                implementation(libs.androidx.activity.compose)
-                implementation(libs.androidx.lifecycle.runtime.compose)
-                implementation(libs.androidx.camera.core)
-                implementation(libs.androidx.camera.camera2)
-                implementation(libs.androidx.camera.lifecycle)
-                implementation(libs.androidx.camera.view)
-                implementation(libs.accompanist.permissions)
-                implementation(libs.core)
-                implementation(libs.kotlinx.coroutines.core)
-                implementation(libs.androidx.ui)
-                implementation(libs.androidx.ui.tooling.preview)
-                implementation(libs.androidx.material.icons.extended)
-                implementation(libs.androidx.exifinterface)
-            }
+        androidMain.dependencies {
+            implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.lifecycle.runtime.compose)
+            implementation(libs.androidx.camera.core)
+            implementation(libs.androidx.camera.camera2)
+            implementation(libs.androidx.camera.lifecycle)
+            implementation(libs.androidx.camera.view)
+            implementation(libs.accompanist.permissions)
+            implementation(libs.core)
+            implementation(libs.androidx.ui)
+            implementation(libs.androidx.ui.tooling.preview)
+            implementation(libs.androidx.exifinterface)
         }
         val iosResourcesDir =
             project.findProperty("iosResourcesDir") as? String ?: "src/iosMain/resources"
@@ -302,36 +296,14 @@ kotlin {
                 duplicatesStrategy = DuplicatesStrategy.INCLUDE
             }
         }
-        
-        val jvmMain by getting {
-            dependencies {
-                implementation(libs.compose.ui)
-                implementation(libs.compose.material)
-                implementation(libs.compose.foundation)
-                implementation(libs.compose.runtime)
-                implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.10.2")
-            }
+        jvmMain.dependencies {
+            implementation(libs.kotlinx.coroutines.swing)
         }
-        
-        val jsMain by getting {
-            dependencies {
-                implementation(libs.compose.runtime)
-                implementation(libs.compose.ui)
-                implementation(libs.compose.foundation)
-                implementation(libs.compose.material)
-                implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
-            }
+        jsMain.dependencies {
+
         }
-        
-        val wasmJsMain by getting {
-            dependencies {
-                implementation(libs.compose.runtime)
-                implementation(libs.compose.ui)
-                implementation(libs.compose.foundation)
-                implementation(libs.compose.material)
-                implementation("org.jetbrains.compose.material:material-icons-extended:1.7.3")
-            }
+        wasmJsMain.dependencies {
+
         }
 
         tasks.register("copyLocalizationResources") {

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.android.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.android.kt
@@ -16,8 +16,14 @@ import java.io.ByteArrayOutputStream
 import kotlin.math.max
 import androidx.core.net.toUri
 import androidx.core.graphics.scale
+import kotlinx.io.Source
+import kotlinx.io.asSource
+import kotlinx.io.buffered
+import kotlinx.io.files.FileNotFoundException
+import kotlinx.io.readByteArray
 import java.lang.Class.forName
 import java.io.File
+import java.net.URI
 
 
 private val painterCache     = object : LruCache<String, Painter>(50) {}
@@ -350,3 +356,28 @@ private fun compressBitmapToByteArrayDirect(bitmap: Bitmap): ByteArray {
         ByteArray(0)
     }
 }
+private fun openUriSource(uri: String): Source {
+    val androidUri = uri.toUri()
+    return getApplicationContext().contentResolver
+        .openInputStream(androidUri)
+        ?.asSource()?.buffered()
+        ?: throw FileNotFoundException("Cannot open: $uri")
+}
+
+
+actual val PhotoResult.absolutePath: String
+    get() {
+        try {
+            val file = if (uri.startsWith("content://")) {
+                File(getApplicationContext().cacheDir, fileName ?: "photo.jpg").apply {
+                    writeBytes(openUriSource(uri).readByteArray())
+                }
+            } else if (uri.startsWith("file://"))
+                File(URI(uri))
+            else
+                throw FileNotFoundException("Cannot open: $uri")
+            return file.absolutePath
+        } catch (e: Exception) {
+            throw FileNotFoundException("Cannot open: $uri ${e::class.simpleName}")
+        }
+    }

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.kt
@@ -3,6 +3,12 @@ package io.github.ismoy.imagepickerkmp.domain.extensions
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.painter.Painter
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import kotlinx.io.RawSink
+import kotlinx.io.RawSource
+import kotlinx.io.Source
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 
 /**
  * Extension function to load the photo data as ByteArray from the URI.
@@ -33,3 +39,58 @@ expect fun PhotoResult.loadImageBitmap(): ImageBitmap?
  * @return Painter that can be used directly in Image composable, or null if loading fails.
  */
 expect fun PhotoResult.loadPainter(): Painter?
+
+/**
+ * Gets the absolute file system path of the photo.
+ *
+ * @return String representing the absolute path to the photo file
+ */
+expect val PhotoResult.absolutePath: String
+
+/**
+ * Converts the photo result to a [Path] object for file system operations.
+ *
+ * @return Path instance representing the photo's location
+ */
+fun PhotoResult.asPath(): Path {
+    return Path(absolutePath)
+}
+
+/**
+ * Creates a [RawSource] for reading the photo file directly.
+ * Use this for low-level file operations without buffering.
+ *
+ * @return RawSource for the photo file
+ */
+fun PhotoResult.asRawSource(): RawSource {
+    return SystemFileSystem
+        .source(asPath())
+}
+
+/**
+ * Creates a buffered [Source] for efficient reading of the photo file.
+ * This is recommended for most read operations as it provides better performance.
+ *
+ * @return Buffered Source for the photo file
+ */
+fun PhotoResult.asSource(): Source {
+    return asRawSource().use {
+        it.buffered()
+    }
+}
+
+/**
+ * Transfers the entire photo file content to the specified [RawSink].
+ * Useful for copying or uploading the photo data.
+ *
+ * @param sink The RawSink to write the photo data to
+ *
+ * Example:
+ * ```
+ * val outputFile = SystemFileSystem.sink(Path("copy.jpg"))
+ * photoResult.transferToSink(outputFile)
+ * ```
+ */
+fun PhotoResult.transferToSink(sink: RawSink) {
+    asSource().transferTo(sink)
+}

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.kt
@@ -57,14 +57,25 @@ fun PhotoResult.asPath(): Path {
 }
 
 /**
+ * Checks whether the photo file actually exists on disk.
+ *
+ * @return Boolean indicating if the photo file exists
+ */
+fun PhotoResult.exists(): Boolean {
+    return SystemFileSystem.exists(asPath())
+}
+
+/**
  * Creates a [RawSource] for reading the photo file directly.
  * Use this for low-level file operations without buffering.
  *
  * @return RawSource for the photo file
  */
 fun PhotoResult.asRawSource(): RawSource {
-    return SystemFileSystem
-        .source(asPath())
+    return if (exists())
+        SystemFileSystem.source(asPath())
+    else
+        error("Photo file deleted or application cache cleared.")
 }
 
 /**
@@ -74,9 +85,7 @@ fun PhotoResult.asRawSource(): RawSource {
  * @return Buffered Source for the photo file
  */
 fun PhotoResult.asSource(): Source {
-    return asRawSource().use {
-        it.buffered()
-    }
+    return asRawSource().buffered()
 }
 
 /**
@@ -92,5 +101,7 @@ fun PhotoResult.asSource(): Source {
  * ```
  */
 fun PhotoResult.transferToSink(sink: RawSink) {
-    asSource().transferTo(sink)
+    asSource().use {
+        it.transferTo(sink)
+    }
 }

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/GalleryPhotoResult.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/GalleryPhotoResult.kt
@@ -5,5 +5,7 @@ package io.github.ismoy.imagepickerkmp.domain.models
  *
  * Both gallery picks and camera captures share the same result model.
  * This alias exists for API readability and backwards compatibility.
+ *
+ * All [PhotoResult] extensions apply directly to this type.
  */
 typealias GalleryPhotoResult = PhotoResult

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/PhotoResult.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/PhotoResult.kt
@@ -11,6 +11,26 @@ package io.github.ismoy.imagepickerkmp.domain.models
  * @property fileSize The size of the file in bytes, if available.
  * @property mimeType The MIME type of the file (e.g., "image/jpeg", "application/pdf").
  * @property exif EXIF metadata including GPS location data (only available when includeExif is enabled).
+ *
+ * ## Available Extensions
+ *
+ * ### Data Access
+ * - [.absolutePath] — Absolute file system path of the photo
+ * - [.asPath()] — Converts to a [kotlinx.io.files.Path] object
+ * - [.exists()] — Checks whether the file exists on disk
+ *
+ * ### Reading
+ * - [.loadBytes()] — Reads the file into a [ByteArray]
+ * - [.loadBase64()] — Reads the file and encodes it as a `Base64` string
+ * - [.asRawSource()] — Opens an unbuffered [kotlinx.io.RawSource] for reading
+ * - [.asSource()] — Opens a buffered [kotlinx.io.Source] for efficient reading
+ *
+ * ### UI / Compose
+ * - [.loadImageBitmap()] — Decodes the file into an [androidx.compose.ui.graphics.ImageBitmap] for Compose
+ * - [.loadPainter()] — Decodes the file into a [androidx.compose.ui.graphics.painter.Painter] for Compose
+ *
+ * ### Writing
+ * - [.transferToSink()] — Transfers the file content to a [kotlinx.io.RawSink]
  */
 data class PhotoResult(
     val uri: String,

--- a/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.ios.kt
+++ b/library/src/iosMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.ios.kt
@@ -12,10 +12,13 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.useContents
 import kotlinx.cinterop.usePinned
+import kotlinx.io.files.FileNotFoundException
 import org.jetbrains.skia.Image
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.base64EncodedStringWithOptions
 import platform.Foundation.create
@@ -26,6 +29,8 @@ import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
 import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 import platform.Foundation.NSLock
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.writeToURL
 
 
 private class SynchronizedCache<V> {
@@ -229,4 +234,32 @@ private fun resizeImageIOS(image: UIImage, newSize: CValue<platform.CoreGraphics
     return resizedImage ?: image
 }
 
+private val cacheDirectoryURL: NSURL by lazy {
+    NSFileManager.defaultManager
+        .URLsForDirectory(NSCachesDirectory, NSUserDomainMask)
+        .first() as NSURL
+}
 
+private fun String.toNSURL(): NSURL =
+    NSURL.URLWithString(this) ?: throw IllegalArgumentException("Invalid URL: $this")
+
+private fun NSURL.readData(): NSData =
+    NSData.dataWithContentsOfURL(this)
+        ?: throw FileNotFoundException("Cannot read: $absoluteString")
+
+actual val PhotoResult.absolutePath: String
+    get() {
+        val compressedData = uri.toNSURL()
+            .readData()
+
+        val destURL = cacheDirectoryURL
+            .URLByAppendingPathComponent(fileName ?: "photo.jpg")
+            ?: throw IllegalStateException("Could not build cache path for: $fileName")
+
+        check(compressedData.writeToURL(destURL, atomically = true)) {
+            "Failed to write file to ${destURL.path ?: destURL}"
+        }
+
+        return destURL.path
+            ?: throw IllegalStateException("Cache file URL has no path: $destURL")
+    }

--- a/library/src/jsMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.js.kt
+++ b/library/src/jsMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.js.kt
@@ -48,3 +48,6 @@ actual fun PhotoResult.loadPainter(): Painter? {
         null
     }
 }
+
+actual val PhotoResult.absolutePath: String
+    get() = uri

--- a/library/src/jvmMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.jvm.kt
+++ b/library/src/jvmMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.jvm.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
 import org.jetbrains.skia.Image
 import java.io.File
+import java.net.URL
 import java.util.Base64
 
 /**
@@ -57,3 +58,6 @@ actual fun PhotoResult.loadPainter(): Painter? {
         null
     }
 }
+
+actual val PhotoResult.absolutePath: String
+    get() = File(java.net.URI(uri)).absolutePath

--- a/library/src/jvmMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.jvm.kt
+++ b/library/src/jvmMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.jvm.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
 import org.jetbrains.skia.Image
 import java.io.File
-import java.net.URL
 import java.util.Base64
 
 /**

--- a/library/src/wasmJsMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.wasmJs.kt
+++ b/library/src/wasmJsMain/kotlin/io/github/ismoy/imagepickerkmp/domain/extensions/PhotoResultExtensions.wasmJs.kt
@@ -16,3 +16,6 @@ actual fun PhotoResult.loadBase64(): String = ""
 actual fun PhotoResult.loadImageBitmap(): ImageBitmap? = null
 
 actual fun PhotoResult.loadPainter(): Painter? = null
+
+actual val PhotoResult.absolutePath: String
+    get() = uri


### PR DESCRIPTION
## Description

Add absolutePath support and kotlinx-io extensions for PhotoResult, enabling cross-platform file path retrieval and efficient I/O operations in common code.

Previously, accessing the underlying file path of a `PhotoResult` required platform-specific handling, and working with photo data in common code lacked convenient I/O utilities. This update introduces a standardized `absolutePath` property across all platforms and provides `kotlinx-io` extension functions for seamless file operations.

**Old behavior:**
- No common API to get absolute file path
- Platform-specific workarounds needed for file access
- Manual stream handling required to copy or read photo data

**New behavior:**
- `PhotoResult.absolutePath` returns the absolute file path on all platforms
- Extensions like `asPath()`, `asSource()`, `transferToSink()` simplify common I/O operations
- `content://` URIs on Android are automatically cached to temporary files
- iOS photos are persisted to `NSCachesDirectory` for reliable path access

**Platform implementations:**
- **Android:** `content://` URIs → cached to temp file; `file://` URIs → direct resolution
- **iOS:** Photo data → written to `NSCachesDirectory`
- **JVM/Desktop:** Standard `java.net.URI` and `File` resolution
- **Web (JS/Wasm):** Returns original URI (default implementation)

Fixes need for platform-specific file path handling and adds ergonomic I/O utilities for common code.

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring / code cleanup (no functional changes)
- [ ] Performance improvement
- [ ] Test additions or improvements
- [ ] Security fix

---

## Testing

- [ ] Unit tests (commonTest)
- [ ] Android instrumented tests
- [ ] iOS tests
- [x] Tested manually on Android
- [ ] Tested manually on iOS
- [ ] Tested on Desktop (JVM)
- [ ] Tested on Web (JS / Wasm)

**Test configuration:**
- Emulator: Pixel_6_API_34
- OS version: Android 14 (API 34)
- Library version tested against: 2.0.39

---

## Checklist

- [x] My code follows the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
- [ ] I have run `./gradlew detekt` and there are no new issues
- [ ] I have added/updated tests to cover my changes
- [ ] All existing tests pass (`./gradlew test`)
- [x] I have updated the relevant documentation (KDoc, `docs/`, README if needed)
- [ ] I have added an entry to `docs/CHANGELOG.md` under `[Unreleased]`
- [ ] My branch is based on `develop` (not `main`)
- [x] I have not introduced any breaking API changes (or they are documented and justified)

---

## Additional Context

### Why this matters
- Developers building cross-platform apps need consistent file path access
- `kotlinx-io` is the standard for multiplatform I/O in Kotlin
- Current workarounds involve `expect/actual` boilerplate or platform checks
- Caching `content://` URIs on Android prevents "File not found" errors after app restart

### Dependency addition
```kotlin
// build.gradle.kts
commonMain.dependencies {
    api(libs.kotlinx.io.core)
}
```

### Migration note for existing users
- No breaking changes - existing `PhotoResult` usage unchanged
- New properties and extensions available without migration