### PR TITLE
Feature/camera scale type

### DIFF
--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
@@ -34,6 +34,7 @@ import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.DELAY
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CameraScaleType
 import io.github.ismoy.imagepickerkmp.presentation.ui.extensions.activity
 import io.github.ismoy.imagepickerkmp.presentation.ui.utils.playShutterSound
 import io.github.ismoy.imagepickerkmp.presentation.ui.utils.rememberCameraManager
@@ -101,8 +102,8 @@ fun CameraCapturePreview(
         AndroidView(
                 factory = { context ->
                     PreviewView(context).apply {
-                        scaleType = PreviewView.ScaleType.FILL_CENTER
-                    
+                        scaleType = previewConfig.cameraScaleType.toPreviewViewScaleType()
+
                         implementationMode = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
                             PreviewView.ImplementationMode.COMPATIBLE
                         } else {
@@ -177,4 +178,13 @@ fun CameraCapturePreview(
         }
         FlashOverlay(visible = stateHolder?.showFlashOverlay ?: false)
     }
+}
+
+private fun CameraScaleType.toPreviewViewScaleType(): PreviewView.ScaleType = when (this) {
+    CameraScaleType.FILL_CENTER -> PreviewView.ScaleType.FILL_CENTER
+    CameraScaleType.FILL_START -> PreviewView.ScaleType.FILL_START
+    CameraScaleType.FILL_END -> PreviewView.ScaleType.FILL_END
+    CameraScaleType.FIT_CENTER -> PreviewView.ScaleType.FIT_CENTER
+    CameraScaleType.FIT_START -> PreviewView.ScaleType.FIT_START
+    CameraScaleType.FIT_END -> PreviewView.ScaleType.FIT_END
 }

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
@@ -7,14 +7,12 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cached
 import androidx.compose.runtime.Composable
@@ -32,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import io.github.ismoy.imagepickerkmp.data.models.FlashMode
 import io.github.ismoy.imagepickerkmp.domain.config.CameraPreviewConfig
-import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.BackgroundColor
 import io.github.ismoy.imagepickerkmp.domain.config.ImagePickerUiConstants.DELAY_TO_TAKE_PHOTO
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
@@ -84,8 +81,6 @@ fun CameraCapturePreview(
         playShutterSound()
         stateHolder?.capturePhoto(onPhotoResult, onError, compressionLevel, includeExif, redactGpsData)
     }
-    val isDark = isSystemInDarkTheme()
-    val backgroundColor = if (isDark) MaterialTheme.colors.background else BackgroundColor
     val resolvedButtonColor = previewConfig.uiConfig.buttonColor ?: Color.Gray
     val resolvedIconColor = previewConfig.uiConfig.iconColor ?: Color.White
     val resolvedButtonSize = previewConfig.uiConfig.buttonSize ?: 56.dp
@@ -102,7 +97,7 @@ fun CameraCapturePreview(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().background(backgroundColor)) {
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
         AndroidView(
                 factory = { context ->
                     PreviewView(context).apply {

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
@@ -173,7 +173,8 @@ private fun CameraAndPreview(
         previewConfig = CameraPreviewConfig(
             captureButtonSize = cameraCaptureConfig.captureButtonSize,
             uiConfig = cameraCaptureConfig.uiConfig,
-            cameraCallbacks = cameraCaptureConfig.cameraCallbacks
+            cameraCallbacks = cameraCaptureConfig.cameraCallbacks,
+            cameraScaleType = cameraCaptureConfig.cameraScaleType,
         ),
         compressionLevel = cameraCaptureConfig.compressionLevel,
         includeExif = cameraCaptureConfig.includeExif,

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
@@ -9,6 +9,7 @@ import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.CompressionLevel
 import io.github.ismoy.imagepickerkmp.domain.models.MimeType
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CameraScaleType
 
 /**
  * Configuration for the visual styling of camera UI elements.
@@ -161,6 +162,11 @@ data class CropConfig(
  *   post-capture confirmation screen. See [PermissionAndConfirmationConfig].
  * @property cropConfig Configuration for the interactive crop UI shown after capture.
  *   See [CropConfig].
+ * @property cameraScaleType How the camera preview is scaled inside its viewport.
+ *   Defaults to [CameraScaleType.FILL_CENTER] (preserves prior behavior — fills the
+ *   viewport, cropping the camera feed to fit). Use [CameraScaleType.FIT_CENTER] to
+ *   letterbox the preview so the viewfinder framing matches the captured image.
+ *   Currently applied on Android only.
  */
 @Suppress("EndOfSentenceFormat")
 data class CameraCaptureConfig(
@@ -172,7 +178,8 @@ data class CameraCaptureConfig(
     val uiConfig: UiConfig = UiConfig(),
     val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
     val permissionAndConfirmationConfig: PermissionAndConfirmationConfig = PermissionAndConfirmationConfig(),
-    val cropConfig: CropConfig = CropConfig()
+    val cropConfig: CropConfig = CropConfig(),
+    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
 )
 
 /**
@@ -271,7 +278,8 @@ data class ImagePickerConfig(
 data class CameraPreviewConfig(
     val captureButtonSize: Dp = 72.dp,
     val uiConfig: UiConfig = UiConfig(),
-    val cameraCallbacks: CameraCallbacks = CameraCallbacks()
+    val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
+    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
 )
 
 /**

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/CameraScaleType.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/models/CameraScaleType.kt
@@ -1,0 +1,28 @@
+package io.github.ismoy.imagepickerkmp.domain.models
+
+/**
+ * Controls how the camera preview is scaled inside its viewport.
+ *
+ * The preview surface and the captured image share an aspect ratio (4:3), but the
+ * viewport that hosts the preview typically does not. The scale type decides how
+ * the preview is fitted into that mismatched viewport.
+ *
+ * - **FILL_** values fill the viewport entirely and crop whatever does not fit.
+ *   The visible viewfinder will be narrower (or wider) than the captured image.
+ * - **FIT_** values letterbox the preview so the entire camera feed is visible.
+ *   The viewfinder framing matches the captured image exactly.
+ *
+ * Only [FILL_CENTER] and [FIT_CENTER] are commonly useful. The remaining values
+ * mirror [androidx.camera.view.PreviewView.ScaleType] for completeness.
+ *
+ * Currently applied on Android only. iOS uses the system camera UI, where preview
+ * and capture framing already match.
+ */
+enum class CameraScaleType {
+    FILL_CENTER,
+    FILL_START,
+    FILL_END,
+    FIT_CENTER,
+    FIT_START,
+    FIT_END,
+}

--- a/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfigTest.kt
+++ b/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfigTest.kt
@@ -3,6 +3,7 @@ package io.github.ismoy.imagepickerkmp.domain.config
 import io.github.ismoy.imagepickerkmp.domain.models.CapturePhotoPreference
 import io.github.ismoy.imagepickerkmp.domain.models.MimeType
 import io.github.ismoy.imagepickerkmp.domain.models.PhotoResult
+import io.github.ismoy.imagepickerkmp.domain.models.CameraScaleType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,17 +38,20 @@ class ImagePickerConfigTest {
     @Test
     fun `CameraCaptureConfig should have default values`() {
         val config = CameraCaptureConfig()
-        
+
         assertEquals(CapturePhotoPreference.BALANCED, config.preference)
+        assertEquals(CameraScaleType.FILL_CENTER, config.cameraScaleType)
     }
 
     @Test
     fun `CameraCaptureConfig should allow custom values`() {
         val config = CameraCaptureConfig(
-            preference = CapturePhotoPreference.FAST
+            preference = CapturePhotoPreference.FAST,
+            cameraScaleType = CameraScaleType.FIT_CENTER,
         )
-        
+
         assertEquals(CapturePhotoPreference.FAST, config.preference)
+        assertEquals(CameraScaleType.FIT_CENTER, config.cameraScaleType)
     }
 
     @Test
@@ -86,10 +90,18 @@ class ImagePickerConfigTest {
     @Test
     fun `CameraPreviewConfig should have default values`() {
         val config = CameraPreviewConfig()
-        
+
         assertFalse(config.captureButtonSize.value == 0f)
         assertEquals(null, config.uiConfig.buttonColor)
         assertEquals(null, config.cameraCallbacks.onCameraReady)
+        assertEquals(CameraScaleType.FILL_CENTER, config.cameraScaleType)
+    }
+
+    @Test
+    fun `CameraPreviewConfig should allow custom cameraScaleType`() {
+        val config = CameraPreviewConfig(cameraScaleType = CameraScaleType.FIT_CENTER)
+
+        assertEquals(CameraScaleType.FIT_CENTER, config.cameraScaleType)
     }
 
     @Test


### PR DESCRIPTION
## Why

The Android `PreviewView` is hardcoded to `FILL_CENTER`, which crops the 4:3 camera feed to fit tall phone viewports (~9:19+ on modern devices). The captured image, however, is saved at full 4:3 — so the confirmation screen reveals content on the left/right that was never visible during framing. Users frame their shot against one rectangle and get back a wider one.

Same root cause as #76.

## What

Expose a new `CameraScaleType` enum (mirrors `androidx.camera.view.PreviewView.ScaleType`) on `CameraCaptureConfig` and `CameraPreviewConfig`. Callers can opt into `FIT_CENTER` to letterbox the preview so the viewfinder framing matches the captured image:

```kotlin
CameraCaptureConfig(
    cameraScaleType = CameraScaleType.FIT_CENTER,
)
```

Default remains `FILL_CENTER`, so existing behavior is preserved — fully backwards-compatible.

The preview background is now black, the conventional color for camera letterboxing — so when `FIT_CENTER` leaves bars on the top and bottom, they blend with the standard camera UI rather than showing the app's theme background.

Fixes #76

