### PR TITLE
Install the Simplified Chinese language pack

### DIFF
--- a/library/src/commonMain/composeResources/values-zh/strings.xml
+++ b/library/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="camera_permission_required">需要相机权限</string>
+    <string name="camera_permission_description">需要相机权限才能拍摄照片，请在设置中授予该权限</string>
+    <string name="open_settings">打开设置</string>
+    <string name="camera_permission_denied">相机权限已被拒绝</string>
+    <string name="camera_permission_denied_description">需要相机权限才能拍摄照片，请授予相关权限</string>
+    <string name="grant_permission">授予权限</string>
+    <string name="camera_permission_permanently_denied">相机权限被永久拒绝</string>
+    <string name="gallery_permission_required">需要存储权限</string>
+    <string name="gallery_permission_description">需要存储访问权限才能从相册选择图片，请授予该权限</string>
+    <string name="gallery_permission_denied">存储权限已被拒绝</string>
+    <string name="gallery_permission_denied_description">需要存储权限才能选择图片，请在应用设置中开启权限</string>
+    <string name="gallery_grant_permission">授予权限</string>
+    <string name="gallery_btn_settings">打开设置</string>
+
+    <string name="image_confirmation_title">您对拍摄的照片满意吗？</string>
+    <string name="accept_button">确认使用</string>
+    <string name="retry_button">重新拍摄</string>
+
+    <string name="select_option_dialog_title">请选择操作</string>
+    <string name="take_photo_option">拍照</string>
+    <string name="select_from_gallery_option">从相册选择</string>
+    <string name="cancel_option">取消</string>
+
+    <string name="preview_image_description">预览</string>
+    <string name="hd_quality_description">高清</string>
+    <string name="sd_quality_description">标清</string>
+
+    <string name="invalid_context_error">上下文无效，必须为ComponentActivity</string>
+    <string name="photo_capture_error">照片拍摄失败</string>
+    <string name="gallery_selection_error">相册选择失败</string>
+    <string name="permission_error">发生权限异常</string>
+    <string name="mime_type_mismatch_error">所选文件格式不支持，允许的格式：%1$s</string>
+
+    <string name="image_crop_view_title">裁剪图片</string>
+    <string name="image_crop_view_cancel_description">取消</string>
+    <string name="image_crop_view_apply_description">确定</string>
+    <string name="image_crop_view_rectangular_description">矩形裁剪</string>
+    <string name="image_crop_view_circular_description">圆形裁剪</string>
+    <string name="image_crop_view_zoom_label">缩放</string>
+    <string name="image_crop_view_rotation_label">旋转</string>
+</resources>


### PR DESCRIPTION
# Description

This Pull Request adds the Simplified Chinese (`values-zh`) localization support for the library. Previously, Chinese strings were missing, causing the UI to default to English even when the user's system language was set to Chinese. 

I have mapped all the existing string keys into the new `values-zh/strings.xml` file with accurate translations.

---

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

---

## Testing

- [x] Tested manually on Android
- [x] Tested manually on iOS

**Test configuration:**
- Device / Emulator: Android Emulator & iOS Simulator
- OS version: Android 14 / iOS 17
- Library version tested against: Local build

---

## Screenshots / Screen Recording (if applicable)

| Before (English Default) | After (Simplified Chinese) |
|--------|-------|
| *(You can drag and drop your screenshots here if you want)* | *(You can drag and drop your screenshots here if you want)* |

---

## Checklist

- [x] My code follows the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
- [x] All existing tests pass (`./gradlew test`)

---

## Additional Notes

The translations strictly follow the context of the library's existing English strings to ensure a natural and user-friendly experience for Chinese developers/users.