### PR TITLE
fix(android): respect silent mode for shutter sound and allow disabling it

### DIFF
--- a/docs/API_REFERENCE.es.md
+++ b/docs/API_REFERENCE.es.md
@@ -303,7 +303,8 @@ data class CameraCaptureConfig(
     val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
     val permissionAndConfirmationConfig: PermissionAndConfirmationConfig = PermissionAndConfirmationConfig(),
     val cropConfig: CropConfig = CropConfig(),
-    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER
+    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
+    val enableShutterSound: Boolean = true
 )
 ```
 
@@ -319,6 +320,7 @@ data class CameraCaptureConfig(
 - `permissionAndConfirmationConfig` - Diálogos de permisos y confirmación.
 - `cropConfig` - Configuración del recorte interactivo tras captura.
 - `cameraScaleType` - Cómo se escala la vista previa en el viewport (`FILL_CENTER` o `FIT_CENTER`). Solo Android.
+- `enableShutterSound` - Si se reproduce el sonido del obturador al capturar. Por defecto: `true`. Solo Android: incluso activado, el sonido se silencia cuando el dispositivo está en modo silencio o vibración. En iOS el sonido del obturador lo reproduce el sistema, las apps no pueden desactivarlo y ya respeta el interruptor de silencio (salvo en dispositivos donde es obligatorio por ley, p. ej. Japón/Corea).
 
 ---
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -720,7 +720,8 @@ data class CameraCaptureConfig(
     val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
     val permissionAndConfirmationConfig: PermissionAndConfirmationConfig = PermissionAndConfirmationConfig(),
     val cropConfig: CropConfig = CropConfig(),
-    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER
+    val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
+    val enableShutterSound: Boolean = true
 )
 ```
 
@@ -735,6 +736,7 @@ data class CameraCaptureConfig(
 - `permissionAndConfirmationConfig` - Permission and confirmation dialogs
 - `cropConfig` - Interactive crop UI configuration
 - `cameraScaleType` - How the camera preview is scaled inside its viewport (Android only). Defaults to `CameraScaleType.FILL_CENTER`
+- `enableShutterSound` - Whether to play a shutter click sound on capture (Android only). Defaults to `true`. Even when enabled, the sound is suppressed while the device is in silent or vibrate mode. On iOS the shutter sound is played by the system, cannot be disabled by apps, and already respects the mute switch (except on devices where it is legally mandated, e.g. Japan/Korea)
 
 **Camera scale type examples:**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to ImagePickerKMP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`CameraCaptureConfig.enableShutterSound` — configurable shutter sound (Android)**
+  - New `enableShutterSound: Boolean` parameter in `CameraCaptureConfig` and `CameraPreviewConfig` — defaults to `true`
+  - Android only: on iOS the shutter sound is played by the system, cannot be disabled by apps, and already respects the mute switch
+
+### Fixed
+
+- **Shutter sound now respects the device silent/vibrate mode (Android)**
+  - The shutter click was played unconditionally via `MediaActionSound`, which ignores the ringer mode on many devices
+  - The sound is now suppressed unless the ringer is in normal mode, matching stock camera app behavior
+  - The shutter sound also no longer plays when the camera is not yet ready to capture
+
 ## [1.0.41] — 2026-05-05
 
 ### Added

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/components/CameraCapturePreview.kt
@@ -79,8 +79,10 @@ fun CameraCapturePreview(
     }
 
     VolumeButtonCapture {
-        playShutterSound()
-        stateHolder?.capturePhoto(onPhotoResult, onError, compressionLevel, includeExif, redactGpsData)
+        if (stateHolder != null) {
+            if (previewConfig.enableShutterSound) playShutterSound(context)
+            stateHolder.capturePhoto(onPhotoResult, onError, compressionLevel, includeExif, redactGpsData)
+        }
     }
     val resolvedButtonColor = previewConfig.uiConfig.buttonColor ?: Color.Gray
     val resolvedIconColor = previewConfig.uiConfig.iconColor ?: Color.White
@@ -152,8 +154,10 @@ fun CameraCapturePreview(
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() }
                 ) {
-                    playShutterSound()
-                    stateHolder?.capturePhoto(onPhotoResult, onError, compressionLevel, includeExif, redactGpsData)
+                    if (stateHolder != null) {
+                        if (previewConfig.enableShutterSound) playShutterSound(context)
+                        stateHolder.capturePhoto(onPhotoResult, onError, compressionLevel, includeExif, redactGpsData)
+                    }
                 }
         )
         Box(

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/screens/CameraCaptureView.kt
@@ -177,6 +177,7 @@ private fun CameraAndPreview(
             uiConfig = cameraCaptureConfig.uiConfig,
             cameraCallbacks = cameraCaptureConfig.cameraCallbacks,
             cameraScaleType = cameraCaptureConfig.cameraScaleType,
+            enableShutterSound = cameraCaptureConfig.enableShutterSound,
         ),
         compressionLevel = cameraCaptureConfig.compressionLevel,
         includeExif = cameraCaptureConfig.includeExif,

--- a/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/utils/playShutterSound.kt
+++ b/library/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/presentation/ui/utils/playShutterSound.kt
@@ -1,9 +1,18 @@
 package io.github.ismoy.imagepickerkmp.presentation.ui.utils
 
+import android.content.Context
+import android.media.AudioManager
 import android.media.MediaActionSound
 
 private val shutterSound: MediaActionSound by lazy { MediaActionSound() }
 
-internal fun playShutterSound() {
-    shutterSound.play(MediaActionSound.SHUTTER_CLICK)
+/**
+ * Plays the shutter click sound, but only when the device ringer is in normal mode.
+ * Silent and vibrate modes suppress the sound, matching stock camera app behavior.
+ */
+internal fun playShutterSound(context: Context) {
+    val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    if (audioManager?.ringerMode == AudioManager.RINGER_MODE_NORMAL) {
+        shutterSound.play(MediaActionSound.SHUTTER_CLICK)
+    }
 }

--- a/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
+++ b/library/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfig.kt
@@ -169,6 +169,11 @@ data class CropConfig(
  *   viewport, cropping the camera feed to fit). Use [CameraScaleType.FIT_CENTER] to
  *   letterbox the preview so the viewfinder framing matches the captured image.
  *   Currently applied on Android only.
+ * @property enableShutterSound Whether to play a shutter click sound on capture.
+ *   Defaults to `true`. Even when enabled, the sound is suppressed while the device
+ *   ringer is in silent or vibrate mode. Applies to Android only: on iOS the shutter
+ *   sound is played by the system, cannot be disabled by apps, and already respects
+ *   the mute switch (except on devices where it is legally mandated).
  */
 @Suppress("EndOfSentenceFormat")
 data class CameraCaptureConfig(
@@ -182,6 +187,7 @@ data class CameraCaptureConfig(
     val permissionAndConfirmationConfig: PermissionAndConfirmationConfig = PermissionAndConfirmationConfig(),
     val cropConfig: CropConfig = CropConfig(),
     val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
+    val enableShutterSound: Boolean = true,
 )
 
 /**
@@ -200,11 +206,27 @@ internal data class ImagePickerConfig(
     val onCropPending: () -> Unit = {}
 )
 
+/**
+ * Configuration for the camera preview composable.
+ *
+ * @property captureButtonSize Size of the shutter/capture button in [Dp]. Defaults to `72.dp`.
+ * @property uiConfig Visual styling overrides for camera UI elements. See [UiConfig].
+ * @property cameraCallbacks Lifecycle event callbacks for camera events. See [CameraCallbacks].
+ * @property cameraScaleType How the camera preview is scaled inside its viewport.
+ *   Defaults to [CameraScaleType.FILL_CENTER]. Currently applied on Android only.
+ * @property enableShutterSound Whether to play a shutter click sound on capture.
+ *   Defaults to `true`. Even when enabled, the sound is suppressed while the device
+ *   ringer is in silent or vibrate mode. Applies to Android only: on iOS the shutter
+ *   sound is played by the system, cannot be disabled by apps, and already respects
+ *   the mute switch (except on devices where it is legally mandated).
+ */
+@Suppress("EndOfSentenceFormat")
 data class CameraPreviewConfig(
     val captureButtonSize: Dp = 72.dp,
     val uiConfig: UiConfig = UiConfig(),
     val cameraCallbacks: CameraCallbacks = CameraCallbacks(),
     val cameraScaleType: CameraScaleType = CameraScaleType.FILL_CENTER,
+    val enableShutterSound: Boolean = true,
 )
 
 /**

--- a/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfigTest.kt
+++ b/library/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/config/ImagePickerConfigTest.kt
@@ -41,6 +41,7 @@ class ImagePickerConfigTest {
 
         assertEquals(CapturePhotoPreference.BALANCED, config.preference)
         assertEquals(CameraScaleType.FILL_CENTER, config.cameraScaleType)
+        assertTrue(config.enableShutterSound)
     }
 
     @Test
@@ -48,10 +49,12 @@ class ImagePickerConfigTest {
         val config = CameraCaptureConfig(
             preference = CapturePhotoPreference.FAST,
             cameraScaleType = CameraScaleType.FIT_CENTER,
+            enableShutterSound = false,
         )
 
         assertEquals(CapturePhotoPreference.FAST, config.preference)
         assertEquals(CameraScaleType.FIT_CENTER, config.cameraScaleType)
+        assertFalse(config.enableShutterSound)
     }
 
     @Test
@@ -95,6 +98,7 @@ class ImagePickerConfigTest {
         assertEquals(null, config.uiConfig.buttonColor)
         assertEquals(null, config.cameraCallbacks.onCameraReady)
         assertEquals(CameraScaleType.FILL_CENTER, config.cameraScaleType)
+        assertTrue(config.enableShutterSound)
     }
 
     @Test
@@ -102,6 +106,13 @@ class ImagePickerConfigTest {
         val config = CameraPreviewConfig(cameraScaleType = CameraScaleType.FIT_CENTER)
 
         assertEquals(CameraScaleType.FIT_CENTER, config.cameraScaleType)
+    }
+
+    @Test
+    fun `CameraPreviewConfig should allow disabling shutter sound`() {
+        val config = CameraPreviewConfig(enableShutterSound = false)
+
+        assertFalse(config.enableShutterSound)
     }
 
     @Test


### PR DESCRIPTION
## Description

On Android the shutter sound was played unconditionally via `MediaActionSound.SHUTTER_CLICK`. That call goes through the system audio stream, which many devices (Samsung in particular) don't mute in silent mode, so users couldn't get rid of the sound by muting their phone or turning the volume down.

Two changes:

1. The shutter sound now respects silent/vibrate mode. It only plays when `AudioManager.ringerMode == RINGER_MODE_NORMAL`, which is how stock camera apps behave. 
2. New `enableShutterSound: Boolean = true` on `CameraCaptureConfig` and `CameraPreviewConfig` for apps that want no sound at all. Android only: on iOS the system plays the shutter sound, apps can't disable it, and it already respects the mute switch (except where it's legally required, e.g. Japan/Korea).

As a side effect of the cleanup, the sound no longer plays when the camera state holder isn't ready, so you can't hear a click without an actual capture anymore.

There's no upstream issue for this; it came out of user reports in our app.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring / code cleanup (no functional changes)
- [ ] Performance improvement
- [x] Test additions or improvements
- [ ] Security fix

---

## Testing

- [x] Unit tests (commonTest)
- [ ] Android instrumented tests
- [ ] iOS tests
- [ ] Tested manually on Android
- [ ] Tested manually on iOS
- [ ] Tested on Desktop (JVM)
- [ ] Tested on Web (JS / Wasm)

I ran `./gradlew :library:test` (Android debug + release unit tests, including commonTest), `./gradlew :library:jvmTest` and `./gradlew :library:detekt` locally; everything passes. `ImagePickerConfigTest` now covers the new flag's default and override.

**Test configuration:**
- Device / Emulator: none (unit tests only)
- OS version: macOS (host)
- Library version tested against: current `develop`

---

## Screenshots / Screen Recording (if applicable)

N/A, audio-only change, nothing visual.

---

## Checklist

- [x] My code follows the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
- [x] I have run `./gradlew detekt` and there are no new issues
- [x] I have added/updated tests to cover my changes
- [x] All existing tests pass (`./gradlew test`)
- [x] I have updated the relevant documentation (KDoc, `docs/`, README if needed)
- [x] I have added an entry to `docs/CHANGELOG.md` under `[Unreleased]`
- [x] My branch is based on `develop` (not `main`)
- [x] I have not introduced any breaking API changes (or they are documented and justified)

---

## Additional Notes

- Respecting the ringer mode is the default rather than opt-in because a muted phone is expected to be quiet. Google Camera and other stock apps do the same.
- The new flag defaults to `true`, so existing integrations keep their behavior while the ringer is in normal mode.
- Docs are updated in `API_REFERENCE.md` and `API_REFERENCE.es.md`. `CameraPreviewConfig` had no KDoc at all, so I added it, which also clears a pre-existing detekt `UndocumentedPublicClass` finding.
- On the legal side: in markets that mandate a shutter sound (Japan/Korea) the enforcement sits in the device firmware, and it applies to the OS-level sound. App-played `MediaActionSound` isn't covered by that, so respecting the ringer mode is in line with what other camera apps already do.
