### PR TITLE
Fix JS target ClassCastException on photo capture

### DIFF
--- a/imagepickerkmp-photo/src/jsMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraRenderer.js.kt
+++ b/imagepickerkmp-photo/src/jsMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraRenderer.js.kt
@@ -214,9 +214,9 @@ private fun showCameraInterface(
                     val result = js("{}")
                     result.uri = imageUrl
                     result.fileName = "camera_capture_$timestamp.png"
-                    result.fileSize = blob.size.toDouble()
-                    result.width = canvas.width.toDouble()
-                    result.height = canvas.height.toDouble()
+                    result.fileSize = blob.size.toLong()
+                    result.width = canvas.width
+                    result.height = canvas.height
                     
                     cleanupCameraResources(stream, overlay)
                     onSuccess(result)
@@ -275,9 +275,9 @@ private fun handleFilePicker(
                                         val fileResult = js("{}")
                                         fileResult.uri = result
                                         fileResult.fileName = file.name
-                                        fileResult.fileSize = file.size.toDouble()
-                                        fileResult.width = 0.0
-                                        fileResult.height = 0.0
+                                        fileResult.fileSize = file.size.toLong()
+                                        fileResult.width = 0
+                                        fileResult.height = 0
                                         
                                         results.push(fileResult)
                                     }
@@ -301,9 +301,9 @@ private fun handleFilePicker(
                                     val fileResult = js("{}")
                                     fileResult.uri = result
                                     fileResult.fileName = file.name
-                                    fileResult.fileSize = file.size.toDouble()
-                                    fileResult.width = 0.0
-                                    fileResult.height = 0.0
+                                    fileResult.fileSize = file.size.toLong()
+                                    fileResult.width = 0
+                                    fileResult.height = 0
                                     
                                     onSuccess(fileResult)
                                 } else {


### PR DESCRIPTION
## Summary
Fixes #143. On the `js` (non-wasm) target, `PlatformCameraRenderer` crashed with a `ClassCastException` on every photo capture (camera and file-picker paths).

Root cause: the dynamic JS result object stored `fileSize`/`width`/`height` via `.toDouble()`, but the consumer read them back with `result.fileSize as Long` / `as Int`. On Kotlin/JS, `Long` is a boxed class instance rather than a native JS number, so a plain `Double` is never `instanceof Long` and the cast always throws.

## Fix
Write the native `Long`/`Int` values at the point the dynamic object is populated (`blob.size.toLong()`, `canvas.width`, `file.size.toLong()`, etc.) instead of masquerading them as `Double`, matching how `wasmJsMain`'s `PlatformCameraRenderer.wasmJs.kt` already assigns real Kotlin types. Consumer-side casts (`as Long`, `as Int`) are unchanged.

## Test plan
- [x] `./gradlew :imagepickerkmp-photo:compileKotlinJs` passes
- [x] No remaining `.toDouble()` call sites in the touched file