### PR TITLE
fix(android): guard camera launch when no camera app is present

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) · Versioning: 
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Android: crash when no camera app is present** — `launchCamera()` launched `MediaStore.ACTION_IMAGE_CAPTURE` unguarded, so an unresolvable intent killed the consuming app with `ActivityNotFoundException`. The throw happened inside the library's own `LaunchedEffect`, so callers could not catch it. It now reports `onError` then `onDismiss` and leaves `result` as `ImagePickerResult.Error`, matching the iOS `CameraPresenter`. Regression introduced in 1.1.0 when the in-app CameraX preview was replaced by the system camera intent
+- **A dismissal following an error no longer overwrites the error** — platforms report an unavailable camera as `onError(...)` then `onDismiss()`, which previously left `result` as `Dismissed`, making "no camera app" indistinguishable from "user cancelled". Affected iOS as well, which now reports `Error` for an unavailable camera instead of `Dismissed`
+- **Terminal outcomes no longer wedge the picker** — supplying a custom `onError`/`onDismiss` to `launchCamera()`/`launchGallery()` left the internal mode active with `result` stuck on `Loading`, so the next launch was silently ignored. Internal state now settles before the caller's callback runs
+- **Android: gallery launch failures are reported with a localized message** rather than the raw `ActivityNotFoundException` text, and follow the same `onError` then `onDismiss` contract as the camera path
+
+### Added
+- `camera_unavailable_error` / `gallery_unavailable_error` translations across all 12 supported languages
+
+---
+
 ## [2.0.1] — 2026-07-28
 
 ### Added

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -423,6 +423,29 @@ fun IOSImagePicker() {
 2. **Permissions**: Camera permission may be denied
 3. **Camera in use**: Another app may be using camera
 4. **Simulator**: Camera not available in simulator (use device)
+5. **No camera app**: On Android the capture goes through the system camera app, which can be
+   absent or disabled (enterprise/kiosk devices, or a user disabling the stock camera)
+
+### The error stays on screen after the picker closes. How do I clear it?
+
+`result` is sticky: `ImagePickerResult.Error` persists until you either start another launch
+(which sets `Loading`) or clear it explicitly. Call `reset()` once you've shown the error:
+
+```kotlin
+is ImagePickerResult.Error -> {
+    ErrorBanner(
+        message = result.exception.message,
+        onDismiss = { picker.reset() }   // back to Idle
+    )
+}
+```
+
+Call `reset()` from an event handler as above, not directly inside the `when` block — writing
+state during composition is what you want to avoid.
+
+This applies to every error, not just an unavailable camera — a MIME-type mismatch or a failed
+gallery read behaves the same way. A dismissal that follows an error does *not* clear it, so
+"no camera app" stays distinguishable from "user cancelled".
 
 ### The app crashes when taking photos. How do I fix it?
 

--- a/imagepicker-core/src/commonMain/resources/translations.yaml
+++ b/imagepicker-core/src/commonMain/resources/translations.yaml
@@ -394,6 +394,34 @@ gallery_selection_error:
   ru: "Ошибка выбора из галереи"
   uk: "Помилка вибору з галереї"
 
+camera_unavailable_error:
+  fr: "Aucune application d'appareil photo n'est disponible sur cet appareil."
+  en: "No camera app is available on this device."
+  es: "No hay ninguna aplicación de cámara disponible en este dispositivo."
+  zh: "此设备上没有可用的相机应用。"
+  ko: "이 기기에서 사용할 수 있는 카메라 앱이 없습니다."
+  ja: "この端末で利用できるカメラアプリがありません。"
+  hi: "इस डिवाइस पर कोई कैमरा ऐप उपलब्ध नहीं है।"
+  th: "ไม่มีแอปกล้องที่ใช้งานได้บนอุปกรณ์นี้"
+  it: "Nessuna app fotocamera disponibile su questo dispositivo."
+  de: "Auf diesem Gerät ist keine Kamera-App verfügbar."
+  ru: "На этом устройстве нет доступного приложения камеры."
+  uk: "На цьому пристрої немає доступного застосунку камери."
+
+gallery_unavailable_error:
+  fr: "Aucune application n'est disponible pour sélectionner des images sur cet appareil."
+  en: "No app is available to select images on this device."
+  es: "No hay ninguna aplicación disponible para seleccionar imágenes en este dispositivo."
+  zh: "此设备上没有可用于选择图片的应用。"
+  ko: "이 기기에서 이미지를 선택할 수 있는 앱이 없습니다."
+  ja: "この端末で画像を選択できるアプリがありません。"
+  hi: "इस डिवाइस पर चित्र चुनने के लिए कोई ऐप उपलब्ध नहीं है।"
+  th: "ไม่มีแอปสำหรับเลือกรูปภาพบนอุปกรณ์นี้"
+  it: "Nessuna app disponibile per selezionare immagini su questo dispositivo."
+  de: "Auf diesem Gerät ist keine App zum Auswählen von Bildern verfügbar."
+  ru: "На этом устройстве нет приложения для выбора изображений."
+  uk: "На цьому пристрої немає застосунку для вибору зображень."
+
 permission_error:
   fr: "Une erreur d'autorisation est survenue"
   en: "Permission error occurred"

--- a/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerState.kt
+++ b/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerState.kt
@@ -49,20 +49,15 @@ internal class GalleryPickerState(
                     singlePickerLauncher.launch(mimeTypesArray)
                 }
             } catch (e: ActivityNotFoundException) {
-                reportLaunchFailure(PhotoCaptureException(gallery_unavailable_error, e))
+                reportLaunchFailure(PhotoCaptureException(gallery_unavailable_error, e), config.onError, config.onDismiss)
             } catch (e: Exception) {
-                reportLaunchFailure(e)
+                reportLaunchFailure(e, config.onError, config.onDismiss)
             }
         }
     }
 
     fun setShouldLaunch() {
         shouldLaunch = true
-    }
-
-    private fun reportLaunchFailure(exception: Exception) {
-        config.onError(exception)
-        config.onDismiss()
     }
 
     fun acceptCrop(croppedResult: PhotoResult) {

--- a/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerState.kt
+++ b/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerState.kt
@@ -1,12 +1,15 @@
 package io.github.ismoy.imagepickerkmp.ui
 
+import android.content.ActivityNotFoundException
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import io.github.ismoy.imagepickerkmp.core.I18nKonfig.Errors.gallery_unavailable_error
 import io.github.ismoy.imagepickerkmp.picker.GalleryPhotoResult
+import io.github.ismoy.imagepickerkmp.picker.PhotoCaptureException
 import io.github.ismoy.imagepickerkmp.picker.PhotoResult
 
 @Composable
@@ -38,21 +41,28 @@ internal class GalleryPickerState(
 
     fun onLaunchEffectHandled(multiplePickerLauncher: androidx.activity.compose.ManagedActivityResultLauncher<Array<String>, List<android.net.Uri>>, singlePickerLauncher: androidx.activity.compose.ManagedActivityResultLauncher<Array<String>, android.net.Uri?>, mimeTypesArray: Array<String>) {
         if (shouldLaunch) {
+            shouldLaunch = false
             try {
                 if (config.allowMultiple) {
                     multiplePickerLauncher.launch(mimeTypesArray)
                 } else {
                     singlePickerLauncher.launch(mimeTypesArray)
                 }
-                shouldLaunch = false
+            } catch (e: ActivityNotFoundException) {
+                reportLaunchFailure(PhotoCaptureException(gallery_unavailable_error, e))
             } catch (e: Exception) {
-                config.onError(e)
+                reportLaunchFailure(e)
             }
         }
     }
 
     fun setShouldLaunch() {
         shouldLaunch = true
+    }
+
+    private fun reportLaunchFailure(exception: Exception) {
+        config.onError(exception)
+        config.onDismiss()
     }
 
     fun acceptCrop(croppedResult: PhotoResult) {

--- a/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraState.kt
+++ b/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraState.kt
@@ -1,5 +1,6 @@
 package io.github.ismoy.imagepickerkmp.ui
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import androidx.compose.runtime.Composable
@@ -12,10 +13,12 @@ import androidx.compose.runtime.setValue
 import io.github.ismoy.imagepickerkmp.camera.AndroidPhotoCaptureManager
 import io.github.ismoy.imagepickerkmp.config.CameraCaptureConfig
 import io.github.ismoy.imagepickerkmp.config.ImagePickerConfig
+import io.github.ismoy.imagepickerkmp.core.I18nKonfig.Errors.camera_unavailable_error
 import io.github.ismoy.imagepickerkmp.core.permissions.PermissionManager
 import io.github.ismoy.imagepickerkmp.core.permissions.PermissionStatus
 import io.github.ismoy.imagepickerkmp.core.permissions.PermissionType
 import io.github.ismoy.imagepickerkmp.picker.ImagePickerConfigResolver
+import io.github.ismoy.imagepickerkmp.picker.PhotoCaptureException
 import io.github.ismoy.imagepickerkmp.picker.PhotoResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -111,8 +114,20 @@ internal class PlatformCameraState(
             includeExif = effectiveCamConfig.includeExif,
             redactGpsData = effectiveCamConfig.redactGpsData
         )
-        val (intent, _) = manager.buildCaptureIntent()
-        launchCamera(intent)
+        // Launched from a LaunchedEffect, so anything thrown here would kill the consuming app.
+        try {
+            val (intent, _) = manager.buildCaptureIntent()
+            launchCamera(intent)
+        } catch (e: ActivityNotFoundException) {
+            reportLaunchFailure(PhotoCaptureException(camera_unavailable_error, e))
+        } catch (e: Exception) {
+            reportLaunchFailure(e)
+        }
+    }
+
+    private fun reportLaunchFailure(exception: Exception) {
+        config.onError(exception)
+        config.onDismiss()
     }
 
     fun acceptCrop(croppedResult: PhotoResult) {

--- a/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraState.kt
+++ b/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraState.kt
@@ -119,15 +119,10 @@ internal class PlatformCameraState(
             val (intent, _) = manager.buildCaptureIntent()
             launchCamera(intent)
         } catch (e: ActivityNotFoundException) {
-            reportLaunchFailure(PhotoCaptureException(camera_unavailable_error, e))
+            reportLaunchFailure(PhotoCaptureException(camera_unavailable_error, e), config.onError, config.onDismiss)
         } catch (e: Exception) {
-            reportLaunchFailure(e)
+            reportLaunchFailure(e, config.onError, config.onDismiss)
         }
-    }
-
-    private fun reportLaunchFailure(exception: Exception) {
-        config.onError(exception)
-        config.onDismiss()
     }
 
     fun acceptCrop(croppedResult: PhotoResult) {

--- a/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/reportLaunchFailure.kt
+++ b/imagepickerkmp-photo/src/androidMain/kotlin/io/github/ismoy/imagepickerkmp/ui/reportLaunchFailure.kt
@@ -1,0 +1,10 @@
+package io.github.ismoy.imagepickerkmp.ui
+
+internal fun reportLaunchFailure(
+    exception: Exception,
+    onError: (Exception) -> Unit,
+    onDismiss: () -> Unit
+) {
+    onError(exception)
+    onDismiss()
+}

--- a/imagepickerkmp-photo/src/androidUnitTest/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerStateLaunchTest.kt
+++ b/imagepickerkmp-photo/src/androidUnitTest/kotlin/io/github/ismoy/imagepickerkmp/ui/GalleryPickerStateLaunchTest.kt
@@ -1,0 +1,105 @@
+package io.github.ismoy.imagepickerkmp.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.net.Uri
+import androidx.activity.compose.ManagedActivityResultLauncher
+import io.github.ismoy.imagepickerkmp.core.I18nKonfig
+import io.github.ismoy.imagepickerkmp.picker.PhotoCaptureException
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The gallery picker is launched from a LaunchedEffect, so a throwing launcher must be reported
+ * through the config callbacks rather than propagate.
+ */
+class GalleryPickerStateLaunchTest {
+
+    private val multipleLauncher =
+        mockk<ManagedActivityResultLauncher<Array<String>, List<Uri>>>(relaxed = true)
+    private val singleLauncher =
+        mockk<ManagedActivityResultLauncher<Array<String>, Uri?>>(relaxed = true)
+    private val mimeTypes = arrayOf("image/*")
+
+    private var capturedError: Exception? = null
+    private var dismissed = false
+
+    private fun makeState(allowMultiple: Boolean = false): GalleryPickerState {
+        val config = GalleryPickerConfig(
+            context = mockk<Context>(),
+            onPhotosSelected = {},
+            onError = { capturedError = it },
+            onDismiss = { dismissed = true },
+            allowMultiple = allowMultiple,
+            mimeTypes = listOf("image/*"),
+            cameraCaptureConfig = null
+        )
+        return GalleryPickerState(config).also { it.setShouldLaunch() }
+    }
+
+    @Test
+    fun onLaunchEffectHandled_whenLauncherSucceeds_reportsNoError() {
+        val state = makeState()
+
+        state.onLaunchEffectHandled(multipleLauncher, singleLauncher, mimeTypes)
+
+        assertNull(capturedError)
+        assertFalse(dismissed)
+        assertFalse(state.shouldLaunch)
+    }
+
+    @Test
+    fun onLaunchEffectHandled_whenNothingHandlesTheIntent_reportsThenDismisses() {
+        val state = makeState()
+        val thrown = ActivityNotFoundException("No Activity found to handle Intent")
+        every { singleLauncher.launch(any()) } throws thrown
+
+        state.onLaunchEffectHandled(multipleLauncher, singleLauncher, mimeTypes)
+
+        val error = capturedError
+        assertTrue("expected PhotoCaptureException but was $error", error is PhotoCaptureException)
+        assertEquals(I18nKonfig.Errors.gallery_unavailable_error, error?.message)
+        assertSame(thrown, error?.cause)
+        assertTrue(dismissed)
+    }
+
+    @Test
+    fun onLaunchEffectHandled_whenMultiplePickerThrows_reportsThenDismisses() {
+        val state = makeState(allowMultiple = true)
+        every { multipleLauncher.launch(any()) } throws ActivityNotFoundException()
+
+        state.onLaunchEffectHandled(multipleLauncher, singleLauncher, mimeTypes)
+
+        assertTrue(capturedError is PhotoCaptureException)
+        assertTrue(dismissed)
+    }
+
+    @Test
+    fun onLaunchEffectHandled_whenLauncherFailsUnexpectedly_reportsThenDismisses() {
+        val state = makeState()
+        val failure = IllegalStateException("Launcher has been unregistered")
+        every { singleLauncher.launch(any()) } throws failure
+
+        state.onLaunchEffectHandled(multipleLauncher, singleLauncher, mimeTypes)
+
+        assertSame(failure, capturedError)
+        assertTrue(dismissed)
+    }
+
+    /** A throwing launcher must not leave shouldLaunch set, or recomposition retries forever. */
+    @Test
+    fun onLaunchEffectHandled_whenLauncherThrows_doesNotRelaunch() {
+        val state = makeState()
+        every { singleLauncher.launch(any()) } throws ActivityNotFoundException()
+
+        state.onLaunchEffectHandled(multipleLauncher, singleLauncher, mimeTypes)
+
+        assertFalse(state.shouldLaunch)
+    }
+}

--- a/imagepickerkmp-photo/src/androidUnitTest/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraStateLaunchTest.kt
+++ b/imagepickerkmp-photo/src/androidUnitTest/kotlin/io/github/ismoy/imagepickerkmp/ui/PlatformCameraStateLaunchTest.kt
@@ -1,0 +1,104 @@
+package io.github.ismoy.imagepickerkmp.ui
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import io.github.ismoy.imagepickerkmp.camera.AndroidPhotoCaptureManager
+import io.github.ismoy.imagepickerkmp.config.ImagePickerConfig
+import io.github.ismoy.imagepickerkmp.core.I18nKonfig
+import io.github.ismoy.imagepickerkmp.core.permissions.PermissionManager
+import io.github.ismoy.imagepickerkmp.picker.PhotoCaptureException
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The camera intent is launched from a LaunchedEffect, so anything thrown there reaches the
+ * consuming app as an uncaught exception.
+ */
+class PlatformCameraStateLaunchTest {
+
+    private val intent = mockk<Intent>()
+    private val uri = mockk<Uri>()
+    private val manager = mockk<AndroidPhotoCaptureManager>(relaxed = true)
+    private val permissionManager = mockk<PermissionManager>(relaxed = true)
+
+    private var capturedError: Exception? = null
+    private var dismissed = false
+
+    private fun makeState(): PlatformCameraState {
+        every { manager.buildCaptureIntent() } returns (intent to uri)
+        val config = ImagePickerConfig(
+            onPhotoCaptured = {},
+            onError = { capturedError = it },
+            onDismiss = { dismissed = true }
+        )
+        return PlatformCameraState(config, permissionManager, manager, TestScope())
+    }
+
+    @Test
+    fun startCamera_whenIntentResolves_launchesAndReportsNoError() {
+        val state = makeState()
+        var launched: Intent? = null
+
+        state.startCamera { launched = it }
+
+        assertSame(intent, launched)
+        assertNull(capturedError)
+    }
+
+    @Test
+    fun startCamera_whenNoActivityHandlesIntent_reportsErrorInsteadOfThrowing() {
+        val state = makeState()
+
+        state.startCamera {
+            throw ActivityNotFoundException("No Activity found to handle Intent")
+        }
+
+        val error = capturedError
+        assertTrue("expected PhotoCaptureException but was $error", error is PhotoCaptureException)
+        assertEquals(I18nKonfig.Errors.camera_unavailable_error, error?.message)
+    }
+
+    @Test
+    fun startCamera_whenNoActivityHandlesIntent_keepsTheCauseForDiagnostics() {
+        val state = makeState()
+        val thrown = ActivityNotFoundException("No Activity found to handle Intent")
+
+        state.startCamera { throw thrown }
+
+        assertSame(thrown, capturedError?.cause)
+    }
+
+    @Test
+    fun startCamera_whenNoActivityHandlesIntent_reportsThenDismisses() {
+        val state = makeState()
+
+        state.startCamera { throw ActivityNotFoundException() }
+
+        assertTrue(capturedError is PhotoCaptureException)
+        assertTrue(dismissed)
+    }
+
+    @Test
+    fun startCamera_whenBuildingTheIntentFails_reportsErrorInsteadOfThrowing() {
+        val failure = IllegalArgumentException("Failed to find configured root")
+        every { manager.buildCaptureIntent() } throws failure
+        val config = ImagePickerConfig(
+            onPhotoCaptured = {},
+            onError = { capturedError = it },
+            onDismiss = { dismissed = true }
+        )
+        val state = PlatformCameraState(config, permissionManager, manager, TestScope())
+
+        state.startCamera { }
+
+        assertSame(failure, capturedError)
+        assertTrue(dismissed)
+    }
+}

--- a/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/ImagePickerKMPState.kt
+++ b/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/ImagePickerKMPState.kt
@@ -19,10 +19,17 @@ class ImagePickerKMPState internal constructor(
 
     internal var activeMode by mutableStateOf<PickerMode>(PickerMode.None)
 
+    // Latched per launch: platforms can report onError then onDismiss, and the first report
+    // clears activeMode, so callbacks cannot live on the mode object.
+    private var consumerOnDismiss: (() -> Unit)? = null
+    private var consumerOnError: ((Exception) -> Unit)? = null
+
     fun reset() {
         result = ImagePickerResult.Idle
         isCropActive = false
         activeMode = PickerMode.None
+        consumerOnDismiss = null
+        consumerOnError = null
     }
 
     fun launchCamera(
@@ -40,11 +47,11 @@ class ImagePickerKMPState internal constructor(
             }
         }
         result = ImagePickerResult.Loading
+        consumerOnDismiss = onDismiss
+        consumerOnError = onError
         activeMode = PickerMode.Camera(
             cameraCaptureConfig = cameraCaptureConfig ?: config.cameraCaptureConfig,
-            enableCrop = config.cropConfig.enabled,
-            onDismiss = onDismiss,
-            onError = onError
+            enableCrop = config.cropConfig.enabled
         )
     }
 
@@ -70,6 +77,8 @@ class ImagePickerKMPState internal constructor(
             }
         }
         result = ImagePickerResult.Loading
+        consumerOnDismiss = onDismiss
+        consumerOnError = onError
         activeMode = PickerMode.Gallery(
             allowMultiple = allowMultiple ?: config.galleryConfig.allowMultiple,
             mimeTypes = mimeTypes ?: config.galleryConfig.mimeTypes,
@@ -78,9 +87,7 @@ class ImagePickerKMPState internal constructor(
             includeExif = includeExif ?: config.galleryConfig.includeExif,
             redactGpsData = redactGpsData ?: config.galleryConfig.redactGpsData,
             mimeTypeMismatchMessage = mimeTypeMismatchMessage ?: config.galleryConfig.mimeTypeMismatchMessage,
-            cameraCaptureConfig = cameraCaptureConfig,
-            onDismiss = onDismiss,
-            onError = onError
+            cameraCaptureConfig = cameraCaptureConfig
         )
     }
 
@@ -92,7 +99,10 @@ class ImagePickerKMPState internal constructor(
 
     internal fun notifyDismiss() {
         isCropActive = false
-        result = ImagePickerResult.Dismissed
+        // A dismiss that follows an error is just teardown; keep the reason visible.
+        if (result !is ImagePickerResult.Error) {
+            result = ImagePickerResult.Dismissed
+        }
         activeMode = PickerMode.None
     }
 
@@ -105,5 +115,17 @@ class ImagePickerKMPState internal constructor(
     internal fun notifyCropPending() {
         isCropActive = true
         result = ImagePickerResult.Idle
+    }
+
+    /** Settles internal state first, so a caller-supplied callback can never wedge the next launch. */
+    internal fun dispatchDismiss() {
+        notifyDismiss()
+        consumerOnDismiss?.invoke()
+    }
+
+    /** Error counterpart of [dispatchDismiss]. */
+    internal fun dispatchError(exception: Exception) {
+        onError(exception)
+        consumerOnError?.invoke(exception)
     }
 }

--- a/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/PickerMode.kt
+++ b/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/PickerMode.kt
@@ -7,9 +7,7 @@ internal sealed interface PickerMode {
     data object None : PickerMode
     data class Camera(
         val cameraCaptureConfig: CameraCaptureConfig,
-        val enableCrop: Boolean,
-        val onDismiss: (() -> Unit)?,
-        val onError: ((Exception) -> Unit)?
+        val enableCrop: Boolean
     ) : PickerMode
     data class Gallery(
         val allowMultiple: Boolean,
@@ -19,8 +17,6 @@ internal sealed interface PickerMode {
         val includeExif: Boolean,
         val redactGpsData: Boolean,
         val mimeTypeMismatchMessage: String?,
-        val cameraCaptureConfig: CameraCaptureConfig?,
-        val onDismiss: (() -> Unit)?,
-        val onError: ((Exception) -> Unit)?
+        val cameraCaptureConfig: CameraCaptureConfig?
     ) : PickerMode
 }

--- a/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/rememberImagePickerKMP.kt
+++ b/imagepickerkmp-photo/src/commonMain/kotlin/io/github/ismoy/imagepickerkmp/picker/rememberImagePickerKMP.kt
@@ -28,11 +28,12 @@ fun rememberImagePickerKMP(
     val notifyCropPendingFn: () -> Unit = remember(state) {
         { currentState.value.notifyCropPending() }
     }
-    val onDismissDefault: () -> Unit = remember(state) {
-        { currentState.value.notifyDismiss() }
+
+    val handleDismiss: () -> Unit = remember(state) {
+        { currentState.value.dispatchDismiss() }
     }
-    val onErrorDefault: (Exception) -> Unit = remember(state) {
-        { e -> currentState.value.onError(e) }
+    val handleError: (Exception) -> Unit = remember(state) {
+        { e -> currentState.value.dispatchError(e) }
     }
 
     when (val mode = state.activeMode) {
@@ -46,8 +47,8 @@ fun rememberImagePickerKMP(
                     enableCrop = mode.enableCrop,
                     onPhotoCaptured = { photo -> notifySuccessFn(listOf(photo)) },
                     onCropPending = notifyCropPendingFn,
-                    onDismiss = mode.onDismiss ?: onDismissDefault,
-                    onError = mode.onError ?: onErrorDefault
+                    onDismiss = handleDismiss,
+                    onError = handleError
                 )
             )
         }
@@ -72,8 +73,8 @@ fun rememberImagePickerKMP(
                 cameraCaptureConfig = galleryCamConfig,
                 onPhotosSelected = notifySuccessFn,
                 onCropPending = notifyCropPendingFn,
-                onDismiss = mode.onDismiss ?: onDismissDefault,
-                onError = mode.onError ?: onErrorDefault
+                onDismiss = handleDismiss,
+                onError = handleError
             )
         }
         is PickerMode.None -> Unit

--- a/imagepickerkmp-photo/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerKMPTest.kt
+++ b/imagepickerkmp-photo/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/ImagePickerKMPTest.kt
@@ -337,44 +337,6 @@ class ImagePickerKMPStateLaunchCameraTest {
     }
 
     @Test
-    fun launchCamera_customOnDismiss_storedInMode() {
-        var called = false
-        val state = makeState()
-        state.launchCamera(onDismiss = { called = true })
-        val mode = state.activeMode as PickerMode.Camera
-        assertNotNull(mode.onDismiss)
-        mode.onDismiss.invoke()
-        assertTrue(called)
-    }
-
-    @Test
-    fun launchCamera_nullOnDismiss_modeHasNullDismiss() {
-        val state = makeState()
-        state.launchCamera(onDismiss = null)
-        val mode = state.activeMode as PickerMode.Camera
-        assertNull(mode.onDismiss)
-    }
-
-    @Test
-    fun launchCamera_customOnError_storedInMode() {
-        var caught: Exception? = null
-        val state = makeState()
-        state.launchCamera(onError = { caught = it })
-        val mode = state.activeMode as PickerMode.Camera
-        assertNotNull(mode.onError)
-        mode.onError.invoke(RuntimeException("cam-err"))
-        assertEquals("cam-err", caught?.message)
-    }
-
-    @Test
-    fun launchCamera_nullOnError_modeHasNullError() {
-        val state = makeState()
-        state.launchCamera(onError = null)
-        val mode = state.activeMode as PickerMode.Camera
-        assertNull(mode.onError)
-    }
-
-    @Test
     fun launchCamera_whileAlreadyActive_isIgnored() {
         val state = makeState()
         state.launchCamera()
@@ -544,44 +506,6 @@ class ImagePickerKMPStateLaunchGalleryTest {
         state.launchGallery()
         val mode = state.activeMode as PickerMode.Gallery
         assertNull(mode.cameraCaptureConfig)
-    }
-
-    @Test
-    fun launchGallery_customOnDismiss_storedInMode() {
-        var called = false
-        val state = makeState()
-        state.launchGallery(onDismiss = { called = true })
-        val mode = state.activeMode as PickerMode.Gallery
-        assertNotNull(mode.onDismiss)
-        mode.onDismiss.invoke()
-        assertTrue(called)
-    }
-
-    @Test
-    fun launchGallery_nullOnDismiss_modeHasNullDismiss() {
-        val state = makeState()
-        state.launchGallery(onDismiss = null)
-        val mode = state.activeMode as PickerMode.Gallery
-        assertNull(mode.onDismiss)
-    }
-
-    @Test
-    fun launchGallery_customOnError_storedInMode() {
-        var caught: Exception? = null
-        val state = makeState()
-        state.launchGallery(onError = { caught = it })
-        val mode = state.activeMode as PickerMode.Gallery
-        assertNotNull(mode.onError)
-        mode.onError.invoke(RuntimeException("gallery-err"))
-        assertEquals("gallery-err", caught?.message)
-    }
-
-    @Test
-    fun launchGallery_nullOnError_modeHasNullError() {
-        val state = makeState()
-        state.launchGallery(onError = null)
-        val mode = state.activeMode as PickerMode.Gallery
-        assertNull(mode.onError)
     }
 
     @Test

--- a/imagepickerkmp-photo/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/state/ImagePickerKMPStateDispatchTest.kt
+++ b/imagepickerkmp-photo/src/commonTest/kotlin/io/github/ismoy/imagepickerkmp/domain/state/ImagePickerKMPStateDispatchTest.kt
@@ -1,0 +1,222 @@
+package io.github.ismoy.imagepickerkmp.domain.state
+
+import io.github.ismoy.imagepickerkmp.picker.ImagePickerKMPConfig
+import io.github.ismoy.imagepickerkmp.picker.ImagePickerKMPState
+import io.github.ismoy.imagepickerkmp.picker.ImagePickerResult
+import io.github.ismoy.imagepickerkmp.picker.PickerMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Terminal-outcome dispatch shared by every platform renderer: activeMode must settle even when
+ * the caller supplied its own callback.
+ */
+class ImagePickerKMPStateDispatchTest {
+
+    private fun makeState(config: ImagePickerKMPConfig = ImagePickerKMPConfig()) =
+        ImagePickerKMPState(config)
+
+    // ── dispatchError without a caller-supplied callback ──────────────────────
+
+    @Test
+    fun dispatchError_withDefaultCallback_setsErrorAndClearsMode() {
+        val state = makeState()
+        val failure = RuntimeException("no camera app")
+
+        state.launchCamera()
+        state.dispatchError(failure)
+
+        val result = assertIs<ImagePickerResult.Error>(state.result)
+        assertSame(failure, result.exception)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    // ── dispatchError with a caller-supplied callback ─────────────────────────
+
+    @Test
+    fun dispatchError_withConsumerCallback_stillClearsMode() {
+        val state = makeState()
+        var received: Exception? = null
+        val failure = RuntimeException("no camera app")
+
+        state.launchCamera(onError = { received = it })
+        state.dispatchError(failure)
+
+        assertSame(failure, received)
+        assertSame(failure, assertIs<ImagePickerResult.Error>(state.result).exception)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    @Test
+    fun launchCamera_afterErrorWithConsumerCallback_relaunches() {
+        val state = makeState()
+
+        state.launchCamera(onError = {})
+        state.dispatchError(RuntimeException("no camera app"))
+
+        state.launchCamera(onError = {})
+
+        assertIs<ImagePickerResult.Loading>(state.result)
+        assertIs<PickerMode.Camera>(state.activeMode)
+    }
+
+    @Test
+    fun dispatchError_onGalleryWithConsumerCallback_stillClearsMode() {
+        val state = makeState()
+        var received: Exception? = null
+        val failure = RuntimeException("no gallery app")
+
+        state.launchGallery(onError = { received = it })
+        state.dispatchError(failure)
+
+        assertSame(failure, received)
+        assertEquals(PickerMode.None, state.activeMode)
+
+        state.launchGallery(onError = {})
+        assertIs<PickerMode.Gallery>(state.activeMode)
+    }
+
+    // ── dispatchDismiss ───────────────────────────────────────────────────────
+
+    @Test
+    fun dispatchDismiss_withConsumerCallback_stillClearsMode() {
+        val state = makeState()
+        var dismissed = false
+
+        state.launchCamera(onDismiss = { dismissed = true })
+        state.dispatchDismiss()
+
+        assertTrue(dismissed)
+        assertIs<ImagePickerResult.Dismissed>(state.result)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    @Test
+    fun dispatchDismiss_onGalleryWithConsumerCallback_stillClearsMode() {
+        val state = makeState()
+        var dismissed = false
+
+        state.launchGallery(onDismiss = { dismissed = true })
+        state.dispatchDismiss()
+
+        assertTrue(dismissed)
+        assertIs<ImagePickerResult.Dismissed>(state.result)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    @Test
+    fun launchCamera_afterDismissWithConsumerCallback_relaunches() {
+        val state = makeState()
+
+        state.launchCamera(onDismiss = {})
+        state.dispatchDismiss()
+
+        state.launchCamera(onDismiss = {})
+
+        assertIs<ImagePickerResult.Loading>(state.result)
+        assertIs<PickerMode.Camera>(state.activeMode)
+    }
+
+    // ── error followed by dismiss (the camera-unavailable sequence) ───────────
+
+    /** The dismiss must not overwrite the Error, or "no camera app" looks like "user cancelled". */
+    @Test
+    fun dispatchError_thenDispatchDismiss_keepsTheError() {
+        val state = makeState()
+        val failure = RuntimeException("no camera app")
+
+        state.launchCamera()
+        state.dispatchError(failure)
+        state.dispatchDismiss()
+
+        assertSame(failure, assertIs<ImagePickerResult.Error>(state.result).exception)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    @Test
+    fun dispatchError_thenDispatchDismiss_invokesBothConsumerCallbacks() {
+        val state = makeState()
+        var received: Exception? = null
+        var dismissed = false
+        val failure = RuntimeException("no camera app")
+
+        state.launchCamera(onDismiss = { dismissed = true }, onError = { received = it })
+        state.dispatchError(failure)
+        state.dispatchDismiss()
+
+        assertSame(failure, received)
+        assertTrue(dismissed)
+        assertIs<ImagePickerResult.Error>(state.result)
+    }
+
+    @Test
+    fun launchCamera_afterErrorThenDismiss_relaunches() {
+        val state = makeState()
+
+        state.launchCamera()
+        state.dispatchError(RuntimeException("no camera app"))
+        state.dispatchDismiss()
+
+        state.launchCamera()
+
+        assertIs<ImagePickerResult.Loading>(state.result)
+        assertIs<PickerMode.Camera>(state.activeMode)
+    }
+
+    /** A plain cancellation after a fresh launch must still report Dismissed. */
+    @Test
+    fun dispatchDismiss_afterRelaunch_reportsDismissedNotTheStaleError() {
+        val state = makeState()
+
+        state.launchCamera()
+        state.dispatchError(RuntimeException("no camera app"))
+
+        state.launchCamera()
+        state.dispatchDismiss()
+
+        assertIs<ImagePickerResult.Dismissed>(state.result)
+    }
+
+    @Test
+    fun dispatchDismiss_whenIdle_isSafeAndClearsMode() {
+        val state = makeState()
+
+        state.dispatchDismiss()
+
+        assertIs<ImagePickerResult.Dismissed>(state.result)
+        assertEquals(PickerMode.None, state.activeMode)
+    }
+
+    // ── latched callbacks don't leak across launches ──────────────────────────
+
+    @Test
+    fun dispatchError_afterRelaunchWithoutCallback_doesNotCallThePreviousOne() {
+        val state = makeState()
+        var staleCallbackCount = 0
+
+        state.launchCamera(onError = { staleCallbackCount++ })
+        state.dispatchError(RuntimeException("first"))
+        assertEquals(1, staleCallbackCount)
+
+        state.launchCamera()
+        state.dispatchError(RuntimeException("second"))
+
+        assertEquals(1, staleCallbackCount)
+    }
+
+    @Test
+    fun dispatchError_afterReset_doesNotCallThePreviousCallback() {
+        val state = makeState()
+        var called = false
+
+        state.launchCamera(onError = { called = true })
+        state.reset()
+        state.dispatchError(RuntimeException("boom"))
+
+        assertFalse(called)
+    }
+}


### PR DESCRIPTION
## Description

On Android, `launchCamera()` fired `MediaStore.ACTION_IMAGE_CAPTURE` unguarded. On devices with no camera app (enterprise/kiosk builds, or the stock camera disabled), the unresolvable intent threw `ActivityNotFoundException` inside the library's own `LaunchedEffect` — crashing the consuming app with no way for callers to catch it. Regression from 1.1.0, when the in-app CameraX preview was replaced by the system camera intent.

This PR guards the camera and gallery launch paths and turns the crash into a reportable outcome:

- A failed launch now reports `onError` then `onDismiss` with a localized message (`camera_unavailable_error` / `gallery_unavailable_error`, all 12 languages), leaving `result` as `ImagePickerResult.Error` — matching the iOS `CameraPresenter` behavior.
- A dismissal that follows an error no longer overwrites the error, so "no camera app" stays distinguishable from "user cancelled". iOS benefits too: an unavailable camera now surfaces as `Error` instead of `Dismissed`.
- Terminal outcomes settle internal state *before* invoking caller-supplied `onError`/`onDismiss` callbacks, so a custom callback can no longer wedge the picker with `result` stuck on `Loading`.

---

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring / code cleanup (no functional changes)
- [ ] Performance improvement
- [x] Test additions or improvements
- [ ] Security fix

---

## Testing

- [x] Unit tests (commonTest)
- [ ] Android instrumented tests
- [ ] iOS tests
- [ ] Tested manually on Android
- [ ] Tested manually on iOS
- [ ] Tested on Desktop (JVM)
- [ ] Tested on Web (JS / Wasm)

New coverage: `ImagePickerKMPStateDispatchTest` (commonTest — dispatch/error/dismiss contract) and `PlatformCameraStateLaunchTest` / `GalleryPickerStateLaunchTest` (androidUnitTest — launch-failure paths, run via `testDebugUnitTest`). iOS, JS, and Wasm targets compile-checked.

**Test configuration:**
- Device / Emulator: none — JVM + Android local unit tests
- OS version: macOS host, JDK 21
- Library version tested against: current `develop` (post-2.0.1)

---

## Screenshots / Screen Recording (if applicable)

Not applicable — no UI changes.

---

## Checklist

- [x] My code follows the [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
- [x] I have run `./gradlew detekt` and there are no new issues
- [x] I have added/updated tests to cover my changes
- [x] All existing tests pass (`./gradlew test`) — except two `CropUtilsTest` failures that pre-exist on `develop`, unrelated to this change (see notes)
- [x] I have updated the relevant documentation (KDoc, `docs/`, README if needed)
- [x] I have added an entry to `docs/CHANGELOG.md` under `[Unreleased]`
- [x] My branch is based on `develop` (not `main`)
- [x] I have not introduced any breaking API changes (or they are documented and justified)

---

## Additional Notes

- `result` stays `Error` until the next launch or an explicit `reset()`; the FAQ gained a section explaining how to clear it. Docs updated: `docs/CHANGELOG.md`, `docs/FAQ.md`.
- An advisory `isCameraAvailable` flag (to hide the camera button up front) was deliberately left out to keep this PR minimal — can be proposed as a follow-up.
- `CropUtilsTest` has two failures (`actual value is not null expected null, but was: TOP_LEFT`) that reproduce identically on `develop` — pre-existing and unrelated to this PR.
